### PR TITLE
#29: init "Add new vehicle" screen

### DIFF
--- a/app/vehicles/_layout.tsx
+++ b/app/vehicles/_layout.tsx
@@ -1,0 +1,24 @@
+import { Stack } from 'expo-router'
+
+const Layout = () => {
+  return (
+    <Stack>
+      <Stack.Screen
+        name="index"
+        options={{
+          // Hide the header for all other routes.
+          headerShown: false,
+        }}
+      />
+      <Stack.Screen
+        name="add-vehicle"
+        options={{
+          // Set the presentation mode to modal for our modal route.
+          presentation: 'modal',
+        }}
+      />
+    </Stack>
+  )
+}
+
+export default Layout

--- a/app/vehicles/add-vehicle.tsx
+++ b/app/vehicles/add-vehicle.tsx
@@ -1,0 +1,47 @@
+import { Link, router, Stack } from 'expo-router'
+import { StatusBar } from 'expo-status-bar'
+import React from 'react'
+
+import TextInput from '@/components/inputs/TextInput'
+import Field from '@/components/shared/Field'
+import Screen from '@/components/shared/Screen'
+import ScreenContent from '@/components/shared/ScreenContent'
+import Typography from '@/components/shared/Typography'
+import { useTranslation } from '@/hooks/useTranslation'
+
+// TODO make sure that modal is what we want and that it works correctly
+const AddVehicleScreen = () => {
+  const t = useTranslation('VehiclesScreen')
+  // If the page was reloaded or navigated to directly, then the modal should be presented as
+  // a full screen page. You may need to change the UI to account for this.
+  const isPresented = router.canGoBack()
+
+  return (
+    <Screen>
+      <Stack.Screen options={{ title: t('addVehicleTitle') }} />
+      {/* Use `../` as a simple way to navigate to the root. This is not analogous to "goBack". */}
+      {!isPresented && (
+        <Link href="../">
+          <Typography variant="default-bold">Dismiss</Typography>
+        </Link>
+      )}
+      {/* Native modals have dark backgrounds on iOS, set the status bar to light content. */}
+      {/* eslint-disable-next-line react/style-prop-object */}
+      <StatusBar style="light" />
+
+      <ScreenContent>
+        <Field label={t('licensePlateFieldLabel')}>
+          <TextInput />
+        </Field>
+        <Field
+          label={t('vehicleNameFieldLabel')}
+          labelInsertArea={<Typography>{t('optional')}</Typography>}
+        >
+          <TextInput />
+        </Field>
+      </ScreenContent>
+    </Screen>
+  )
+}
+
+export default AddVehicleScreen

--- a/app/vehicles/index.tsx
+++ b/app/vehicles/index.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'expo-router'
+
+import Button from '@/components/shared/Button'
+import Screen from '@/components/shared/Screen'
+import ScreenContent from '@/components/shared/ScreenContent'
+
+const VehiclesScreen = () => {
+  return (
+    <Screen>
+      <ScreenContent>
+        <Link href="/vehicles/add-vehicle" asChild>
+          <Button title="Add vehicle" />
+        </Link>
+      </ScreenContent>
+    </Screen>
+  )
+}
+
+export default VehiclesScreen

--- a/components/DeveloperMenu.tsx
+++ b/components/DeveloperMenu.tsx
@@ -36,6 +36,11 @@ const menuItems: MenuItem[] = [
     route: '/add-parking-cards/enter-email-addresses',
   },
   {
+    title: 'Add vehicle',
+    subtitle: 'Flow for adding new vehicle',
+    route: '/vehicles',
+  },
+  {
     title: 'Bottom sheet',
     subtitle: 'Bottom sheet examples',
     route: '/examples/bottom-sheet',

--- a/translations/en.json
+++ b/translations/en.json
@@ -29,5 +29,12 @@
     "addVehicle": "Add vehicle",
     "summary": "Summary",
     "pay": "Pay"
+  },
+  "VehiclesScreen": {
+    "addVehicleTitle": "Add vehicle",
+    "addVehicle": "Add vehicle",
+    "licensePlateFieldLabel": "License plate",
+    "vehicleNameFieldLabel": "Vehicle name",
+    "optional": "Optional"
   }
 }

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -29,5 +29,12 @@
     "addVehicle": "Pridať vozidlo",
     "summary": "Celkom",
     "pay": "Zaplatiť"
+  },
+  "VehiclesScreen": {
+    "addVehicleTitle": "Pridať vozidlo",
+    "addVehicle": "Pridať vozidlo",
+    "licensePlateFieldLabel": "Evidenčné číslo vozidla",
+    "vehicleNameFieldLabel": "Názov vozidla",
+    "optional": "Voliteľné"
   }
 }


### PR DESCRIPTION
Init "Add new vehicle" screen. I tried to use `presentation: "modal"`. We'll see if it works correctly when more screen are added and used together.
Resolves #29

![image](https://github.com/bratislava/paas-mpa/assets/19418224/9e792083-47ce-471f-baa6-67c254c39830)
