### PR TITLE
[#51] implement main menu in detached bottom sheet

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,5 +6,5 @@ module.exports = {
   printWidth: 100,
   trailingComma: 'all',
   plugins: ['prettier-plugin-tailwindcss'],
-  tailwindFunctions: ['cx', 'classnames', 'clsx', 'twMerge'],
+  tailwindFunctions: ['cx', 'classnames', 'clsx', 'twMerge', 'tw', 'cn'],
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,15 +1,122 @@
+import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet'
+import { BottomSheetBackdropProps } from '@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types'
 import { Link } from 'expo-router'
-import { View } from 'react-native'
+import Stack from 'expo-router/stack'
+import { useCallback, useRef } from 'react'
+import { FlatList, StyleSheet } from 'react-native'
 
+import ActionRow from '@/components/actions/ActionRow'
+import BottomSheetContent from '@/components/shared/BottomSheetContent'
 import Button from '@/components/shared/Button'
+import Divider from '@/components/shared/Divider'
+import Icon, { IconName } from '@/components/shared/Icon'
+import ScreenContent from '@/components/shared/ScreenContent'
+import ScreenView from '@/components/shared/ScreenView'
+import { useTranslation } from '@/hooks/useTranslation'
 
-const IndexScreen = () => (
-  <View className="flex-1 p-4 font-belfast">
-    {/* <DeveloperMenu /> */}
-    <Link href="/dev" asChild>
-      <Button>Developer menu</Button>
-    </Link>
-  </View>
-)
+const IndexScreen = () => {
+  const t = useTranslation()
+  const bottomSheetRef = useRef<BottomSheet>(null)
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop {...props} appearsOnIndex={0} disappearsOnIndex={-1} />
+    ),
+    [],
+  )
+
+  const handlePress = () => {
+    bottomSheetRef.current?.expand()
+  }
+
+  const menuItems: {
+    label: string
+    icon: IconName
+    path: string
+  }[] = [
+    {
+      label: t('VehiclesScreen.title'),
+      icon: 'directions-car',
+      path: '/vehicles',
+    },
+    {
+      label: t('ParkingCards.title'),
+      icon: 'card-membership',
+      path: '/parking-cards',
+    },
+    {
+      label: t('PaymentMethods.title'),
+      icon: 'payment',
+      path: '/payment-methods',
+    },
+    {
+      label: t('Tickets.title'),
+      icon: 'local-parking',
+      path: '/tickets',
+    },
+    {
+      label: t('Settings.title'),
+      icon: 'settings',
+      path: '/settings',
+    },
+  ]
+
+  return (
+    <>
+      <ScreenView>
+        <Stack.Screen
+          options={{
+            // headerTransparent: true,
+            headerRight: () => <Icon name="menu" onPress={handlePress} />,
+          }}
+        />
+        <ScreenContent>
+          <Link href="/dev" asChild>
+            <Button>Developer menu</Button>
+          </Link>
+
+          <Button onPress={handlePress} variant="tertiary">
+            Manage app menu
+          </Button>
+        </ScreenContent>
+      </ScreenView>
+
+      <BottomSheet
+        ref={bottomSheetRef}
+        index={-1}
+        // enableDynamicSizing
+        snapPoints={['100%']}
+        backdropComponent={renderBackdrop}
+        detached
+        enablePanDownToClose
+        topInset={50}
+        bottomInset={50}
+        style={styles.sheetContainer}
+      >
+        <BottomSheetContent cn="justify-between flex-1" hideSpacer>
+          <FlatList
+            data={menuItems}
+            renderItem={({ item }) => (
+              <Link asChild href={item.path} onPress={() => bottomSheetRef.current?.close()}>
+                <ActionRow icon={item.icon} label={item.label} />
+              </Link>
+            )}
+          />
+
+          <Divider />
+
+          <ActionRow icon="logout" label="Logout" variant="negative" />
+        </BottomSheetContent>
+      </BottomSheet>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  sheetContainer: {
+    // add horizontal space
+    marginHorizontal: 24,
+  },
+})
 
 export default IndexScreen

--- a/app/parking-cards/enter-paas-account.tsx
+++ b/app/parking-cards/enter-paas-account.tsx
@@ -25,7 +25,7 @@ const Page = () => {
     <ScreenView title={t('addCardsTitle')}>
       <ScreenContent
         continueProps={{
-          href: `/add-parking-cards/verification-sent?emailToVerify=${email}`,
+          href: `/parking-cards/verification-sent?emailToVerify=${email}`,
           isDisabled: !isValid,
         }}
       >

--- a/app/parking-cards/index.tsx
+++ b/app/parking-cards/index.tsx
@@ -1,0 +1,26 @@
+import { Link } from 'expo-router'
+import React from 'react'
+
+import Button from '@/components/shared/Button'
+import ScreenContent from '@/components/shared/ScreenContent'
+import ScreenView from '@/components/shared/ScreenView'
+import Typography from '@/components/shared/Typography'
+import { useTranslation } from '@/hooks/useTranslation'
+
+// TODO
+const Page = () => {
+  const t = useTranslation('ParkingCards')
+
+  return (
+    <ScreenView title={t('title')}>
+      <ScreenContent>
+        <Typography variant="h1">TODO</Typography>
+        <Link asChild href="/parking-cards/enter-paas-account">
+          <Button>{t('addParkingCards')}</Button>
+        </Link>
+      </ScreenContent>
+    </ScreenView>
+  )
+}
+
+export default Page

--- a/app/parking-cards/verification-sent.tsx
+++ b/app/parking-cards/verification-sent.tsx
@@ -19,7 +19,11 @@ const Page = () => {
 
   return (
     // TODO add dynamic href
-    <ScreenView variant="centered" backgroundVariant="dots" continueProps={{ href: '/' }}>
+    <ScreenView
+      variant="centered"
+      backgroundVariant="dots"
+      continueProps={{ href: '/parking-cards' }}
+    >
       <ScreenContent variant="center">
         {/* TODO replace by icon */}
         <AvatarCircle variant="info" />

--- a/app/payment-methods/index.tsx
+++ b/app/payment-methods/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import ScreenContent from '@/components/shared/ScreenContent'
+import ScreenView from '@/components/shared/ScreenView'
+import Typography from '@/components/shared/Typography'
+import { useTranslation } from '@/hooks/useTranslation'
+
+// TODO
+const Page = () => {
+  const t = useTranslation('PaymentMethods')
+
+  return (
+    <ScreenView title={t('title')}>
+      <ScreenContent>
+        <Typography variant="h1">TODO</Typography>
+      </ScreenContent>
+    </ScreenView>
+  )
+}
+
+export default Page

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import ScreenContent from '@/components/shared/ScreenContent'
+import ScreenView from '@/components/shared/ScreenView'
+import Typography from '@/components/shared/Typography'
+import { useTranslation } from '@/hooks/useTranslation'
+
+// TODO
+const Page = () => {
+  const t = useTranslation('Settings')
+
+  return (
+    <ScreenView title={t('title')}>
+      <ScreenContent>
+        <Typography variant="h1">TODO</Typography>
+      </ScreenContent>
+    </ScreenView>
+  )
+}
+
+export default Page

--- a/app/tickets/index.tsx
+++ b/app/tickets/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import ScreenContent from '@/components/shared/ScreenContent'
+import ScreenView from '@/components/shared/ScreenView'
+import Typography from '@/components/shared/Typography'
+import { useTranslation } from '@/hooks/useTranslation'
+
+// TODO
+const Page = () => {
+  const t = useTranslation('Tickets')
+
+  return (
+    <ScreenView title={t('title')}>
+      <ScreenContent>
+        <Typography variant="h1">TODO</Typography>
+      </ScreenContent>
+    </ScreenView>
+  )
+}
+
+export default Page

--- a/app/vehicles/index.tsx
+++ b/app/vehicles/index.tsx
@@ -60,7 +60,7 @@ const VehiclesScreen = () => {
   }
 
   return (
-    <ScreenView>
+    <ScreenView title={t('title')}>
       <ScreenContent>
         <Field label={t('myVehicles')}>
           <FlatList

--- a/components/DeveloperMenu.tsx
+++ b/components/DeveloperMenu.tsx
@@ -32,9 +32,9 @@ const menuItems: MenuItem[] = [
     route: '/onboarding/intro',
   },
   {
-    title: 'Add parking cards',
-    subtitle: 'Flow for adding parking cards',
-    route: '/add-parking-cards/enter-email-addresses',
+    title: 'Parking cards',
+    subtitle: 'All parking cards + flow for adding cards',
+    route: '/parking-cards',
   },
   {
     title: 'Vehicles',

--- a/components/actions/ActionRow.tsx
+++ b/components/actions/ActionRow.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { Pressable, PressableProps, View } from 'react-native'
 
 import Icon, { IconName } from '@/components/shared/Icon'
@@ -18,7 +19,7 @@ const ActionRow = ({
     <Pressable className="py-4" {...rest}>
       <View className="flex-row gap-3">
         <Icon name={icon} className={textColor} />
-        <Typography variant="default-semibold" className={textColor}>
+        <Typography variant="default-semibold" className={clsx('flex-1', textColor)}>
           {label}
         </Typography>
       </View>

--- a/components/shared/BottomSheetContent.tsx
+++ b/components/shared/BottomSheetContent.tsx
@@ -5,14 +5,16 @@ import { View } from 'react-native'
 
 type Props = Omit<ComponentProps<typeof BottomSheetView>, 'className'> & {
   cn?: string
+  hideSpacer?: boolean
 }
 
-const BottomSheetContent = ({ children, cn }: Props) => {
+const BottomSheetContent = ({ children, cn, hideSpacer }: Props) => {
   return (
     <BottomSheetView className={clsx('px-5 py-3', cn)}>
       {children}
+      {/* TODO this should be handled by SafeAreaProvider */}
       {/* spacer */}
-      <View className="h-[29px]" aria-hidden />
+      {!hideSpacer && <View className="h-[29px]" aria-hidden />}
     </BottomSheetView>
   )
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@babel/eslint-parser": "^7.22.11",
+    "@types/url-parse": "^1.4.9",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "@typescript-eslint/parser": "^6.5.0",
     "eslint": "^8.48.0",

--- a/translations/en.json
+++ b/translations/en.json
@@ -33,6 +33,7 @@
     "pay": "Pay"
   },
   "VehiclesScreen": {
+    "title": "Vehicles",
     "addVehicleTitle": "Add vehicle",
     "addVehicle": "Add vehicle",
     "licencePlateFieldLabel": "Licence plate",
@@ -59,5 +60,18 @@
       "saveAsDefault": "Set as default",
       "deleteVehicle": "Delete"
     }
+  },
+  "Settings": {
+    "title": "Settings"
+  },
+  "PaymentMethods": {
+    "title": "Payment methods"
+  },
+  "Tickets": {
+    "title": "Parking tickets"
+  },
+  "ParkingCards": {
+    "title": "Parking cards",
+    "addParkingCards": "Add parking cards"
   }
 }

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -33,6 +33,7 @@
     "pay": "Zaplatiť"
   },
   "VehiclesScreen": {
+    "title": "Vozidlá",
     "addVehicleTitle": "Pridať vozidlo",
     "addVehicle": "Pridať vozidlo",
     "licencePlateFieldLabel": "Evidenčné číslo vozidla",
@@ -59,5 +60,18 @@
       "saveAsDefault": "Uložiť ako predvolené",
       "deleteVehicle": "Odstrániť"
     }
+  },
+  "Settings": {
+    "title": "Nastavenia"
+  },
+  "PaymentMethods": {
+    "title": "Platobné metódy"
+  },
+  "Tickets": {
+    "title": "Parkovacie lístky"
+  },
+  "ParkingCards": {
+    "title": "Parkovacie karty",
+    "addParkingCards": "Pridať parkovacie karty"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4694,6 +4694,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.8.tgz#bb197b9639aa1a04cf464a617fe800cccd92ad5c"
   integrity sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==
 
+"@types/url-parse@^1.4.9":
+  version "1.4.9"
+  resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.9.tgz#443c0d8a4ed3208924fa9134d8f17f79fe9774d0"
+  integrity sha512-pFvFO5NSAVwp8vDSENcAF13eyAcBIv/OXKvMU466CEwu/+5tyUwW05mVzhmcxaU9j9iTSYOypQqbTrYUa1emFw==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"


### PR DESCRIPTION
Implement simple main menu in detached bottom sheet. This solution works with one Stack navigator.
I tried Drawer, but it needs more setup and proper combination with Stack navigation, so I think this is fine for now. Also google maps have similar "modal" when taping on avatar icon.

TODOs if we keep this menu:
- X button instead of handle
- solve header style / X button / transparent bg...

![image](https://github.com/bratislava/paas-mpa/assets/19418224/9c930332-dabd-41c2-826f-6d7863f0dbb6)
![image](https://github.com/bratislava/paas-mpa/assets/19418224/0b492f6d-5f62-4f82-9c38-170a31c8812d)
