### PR TITLE
[#60] implement IconButton and add forwardRef for other components

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -8,7 +8,8 @@ import { FlatList, StyleSheet } from 'react-native'
 import ActionRow from '@/components/actions/ActionRow'
 import BottomSheetContent from '@/components/shared/BottomSheetContent'
 import Button from '@/components/shared/Button'
-import Icon, { IconName } from '@/components/shared/Icon'
+import { IconName } from '@/components/shared/Icon'
+import IconButton from '@/components/shared/IconButton'
 import ScreenContent from '@/components/shared/ScreenContent'
 import ScreenView from '@/components/shared/ScreenView'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -66,7 +67,9 @@ const IndexScreen = () => {
         <Stack.Screen
           options={{
             // headerTransparent: true,
-            headerRight: () => <Icon name="menu" onPress={handlePress} />,
+            headerRight: () => (
+              <IconButton name="menu" accessibilityLabel="Open menu" onPress={handlePress} />
+            ),
           }}
         />
         <ScreenContent>

--- a/components/actions/ActionRow.tsx
+++ b/components/actions/ActionRow.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { forwardRef } from 'react'
 import { Pressable, PressableProps, View } from 'react-native'
 
 import Icon, { IconName } from '@/components/shared/Icon'
@@ -11,22 +12,24 @@ export type ActionRowProps = {
   variant?: 'default' | 'negative'
 } & Omit<PressableProps, 'children'>
 
-const ActionRow = ({ startIcon, endIcon, label, variant = 'default', ...rest }: ActionRowProps) => {
-  const textColor = variant === 'negative' ? 'text-negative' : ''
+const ActionRow = forwardRef<View, ActionRowProps>(
+  ({ startIcon, endIcon, label, variant = 'default', ...rest }, ref) => {
+    const textColor = variant === 'negative' ? 'text-negative' : ''
 
-  return (
-    <Pressable className="py-4" {...rest}>
-      <View className="flex-row gap-3">
-        {startIcon && <Icon name={startIcon} className={textColor} />}
+    return (
+      <Pressable ref={ref} className="py-4" {...rest}>
+        <View className="flex-row gap-3">
+          {startIcon && <Icon name={startIcon} className={textColor} />}
 
-        <Typography variant="default-semibold" className={clsx('flex-1', textColor)}>
-          {label}
-        </Typography>
+          <Typography variant="default-semibold" className={clsx('flex-1', textColor)}>
+            {label}
+          </Typography>
 
-        {endIcon && <Icon name={endIcon} className={textColor} />}
-      </View>
-    </Pressable>
-  )
-}
+          {endIcon && <Icon name={endIcon} className={textColor} />}
+        </View>
+      </Pressable>
+    )
+  },
+)
 
 export default ActionRow

--- a/components/controls/payment-methods/PaymentGate.tsx
+++ b/components/controls/payment-methods/PaymentGate.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native'
 
 import AvatarSquare from '@/components/info/AvatarSquare'
 import FlexRow from '@/components/shared/FlexRow'
-import Icon from '@/components/shared/Icon'
+import IconButton from '@/components/shared/IconButton'
 import PanelPressable from '@/components/shared/PanelPressable'
 import Typography from '@/components/shared/Typography'
 
@@ -16,7 +16,7 @@ const PaymentGate = () => {
           {/* TODO translation */}
           <Typography variant="default-bold">Platobná karta / Apple Pay / Google Pay</Typography>
         </View>
-        <Icon name="expand-more" />
+        <IconButton name="expand-more" accessibilityLabel="Expand more" />
       </FlexRow>
     </PanelPressable>
   )

--- a/components/controls/vehicles/VehicleFieldControl.tsx
+++ b/components/controls/vehicles/VehicleFieldControl.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { View } from 'react-native'
 
 import FlexRow from '@/components/shared/FlexRow'
-import Icon from '@/components/shared/Icon'
+import IconButton from '@/components/shared/IconButton'
 import Panel from '@/components/shared/Panel'
 import Typography from '@/components/shared/Typography'
 import { Vehicle } from '@/hooks/useVehiclesStorage'
@@ -22,7 +22,7 @@ const VehicleFieldControl = ({ vehicle }: Props) => {
           </Typography>
           {vehicle.vehicleName ? <Typography>{vehicle.vehicleName}</Typography> : null}
         </View>
-        <Icon name="expand-more" />
+        <IconButton name="expand-more" accessibilityLabel="Expand more" />
       </FlexRow>
     </Panel>
   )

--- a/components/controls/vehicles/VehicleRow.tsx
+++ b/components/controls/vehicles/VehicleRow.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import FlexRow from '@/components/shared/FlexRow'
-import Icon from '@/components/shared/Icon'
+import IconButton from '@/components/shared/IconButton'
 import Panel from '@/components/shared/Panel'
 import Typography from '@/components/shared/Typography'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -31,7 +31,11 @@ const VehicleRow = ({ vehicle, onContextMenuPress, isDefault }: Props) => {
           )}
         </FlexRow>
         {onContextMenuPress ? (
-          <Icon name="more-vert" onPress={() => onContextMenuPress(vehicle.licencePlate)} />
+          <IconButton
+            name="more-vert"
+            accessibilityLabel="Edit vehicle"
+            onPress={() => onContextMenuPress(vehicle.licencePlate)}
+          />
         ) : null}
       </FlexRow>
       {vehicle.vehicleName ? <Typography>{vehicle.vehicleName}</Typography> : null}

--- a/components/shared/Button.tsx
+++ b/components/shared/Button.tsx
@@ -71,7 +71,7 @@ const Button = forwardRef<View, ButtonProps>(
     const { buttonContainerClassNames, buttonTextClassNames } = buttonClassNames(variant, rest)
 
     return (
-      <Pressable ref={ref} {...rest} className={clsx(buttonContainerClassNames)}>
+      <Pressable ref={ref} hitSlop={4} {...rest} className={clsx(buttonContainerClassNames)}>
         {loading ? (
           <>
             <Icon name="hourglass-top" className={buttonTextClassNames} />

--- a/components/shared/Icon.tsx
+++ b/components/shared/Icon.tsx
@@ -5,7 +5,7 @@ export type IconName = ComponentProps<typeof MaterialIcons>['name']
 
 type Props = {
   name: IconName
-} & Omit<ComponentProps<typeof MaterialIcons>, 'name'>
+} & Omit<ComponentProps<typeof MaterialIcons>, 'name' | 'onPress'>
 
 const Icon = ({ name, size = 24, ...rest }: Props) => {
   return <MaterialIcons name={name} size={size} {...rest} />

--- a/components/shared/IconButton.tsx
+++ b/components/shared/IconButton.tsx
@@ -1,0 +1,44 @@
+import clsx from 'clsx'
+import React, { forwardRef } from 'react'
+import { Pressable, PressableProps, View } from 'react-native'
+
+import Icon, { IconName } from '@/components/shared/Icon'
+
+type Props = {
+  name: IconName
+  accessibilityLabel: string
+  variant?: 'unstyled' | 'white-raised' | 'white-raised-small' | 'dark' | 'dark-small'
+} & Omit<PressableProps, 'children' | 'accessibilityLabel'>
+
+const IconButton = forwardRef<View, Props>(
+  ({ name, accessibilityLabel, variant = 'unstyled', hitSlop, ...rest }, ref) => {
+    return (
+      <Pressable
+        ref={ref}
+        {...rest}
+        hitSlop={hitSlop ?? 12}
+        accessibilityLabel={accessibilityLabel}
+        className={clsx('self-start rounded-full active:opacity-50', {
+          'p-3': variant === 'dark' || variant === 'white-raised',
+          'p-2.5': variant.includes('small'),
+          'bg-white shadow': variant.startsWith('white'),
+          'bg-dark': variant.startsWith('dark'),
+          'bg-dark/50': rest.disabled && variant.startsWith('dark'),
+        })}
+      >
+        {() => (
+          <Icon
+            name={name}
+            className={clsx({
+              'text-dark': variant.startsWith('white'),
+              'text-white': variant.startsWith('dark'),
+              'text-dark/50': rest.disabled && variant.startsWith('white'),
+            })}
+          />
+        )}
+      </Pressable>
+    )
+  },
+)
+
+export default IconButton

--- a/components/shared/Modal.tsx
+++ b/components/shared/Modal.tsx
@@ -4,7 +4,7 @@ import { Modal as ModalRN, ModalProps, View, ViewProps } from 'react-native'
 
 import AvatarCircle from '@/components/info/AvatarCircle'
 import Button from '@/components/shared/Button'
-import Icon from '@/components/shared/Icon'
+import IconButton from '@/components/shared/IconButton'
 import Typography from '@/components/shared/Typography'
 
 export const ModalBackdrop = ({ className, ...rest }: ViewProps) => {
@@ -29,11 +29,11 @@ export const ModalContainer = ({
   return (
     <View {...rest} className={clsx('w-full overflow-hidden rounded bg-white', className)}>
       {children}
-      <Icon
+      <IconButton
         name="close"
         // TODO translation
         // TODO add option to hide this button
-        aria-label="Close dialog"
+        accessibilityLabel="Close dialog"
         className="absolute right-4 top-4"
         onPress={onRequestClose}
       />

--- a/components/showcases/ButtonShowcase.tsx
+++ b/components/showcases/ButtonShowcase.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { View } from 'react-native'
 
 import Button from '@/components/shared/Button'
+import FlexRow from '@/components/shared/FlexRow'
+import IconButton from '@/components/shared/IconButton'
 
 const handlePress = () => {
   // eslint-disable-next-line no-console
@@ -11,6 +13,15 @@ const handlePress = () => {
 const ButtonShowcase = () => (
   // eslint-disable-next-line react-native/no-inline-styles
   <View className="p-4 g-2">
+    <FlexRow cn="justify-start">
+      <IconButton name="add" accessibilityLabel="Add" />
+      <IconButton name="add" accessibilityLabel="Add" variant="white-raised" />
+      <IconButton name="add" accessibilityLabel="Add" variant="dark" />
+      <IconButton name="add" accessibilityLabel="Add" variant="dark-small" />
+      <IconButton name="add" accessibilityLabel="Add" variant="white-raised-small" />
+      <IconButton name="add" accessibilityLabel="Add" variant="dark" disabled />
+      <IconButton name="add" accessibilityLabel="Add" variant="white-raised" disabled />
+    </FlexRow>
     <Button variant="primary" onPress={handlePress}>
       Primary
     </Button>

--- a/components/showcases/ListRowsShowcase.tsx
+++ b/components/showcases/ListRowsShowcase.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import React from 'react'
-import { FlatList, View } from 'react-native'
+import { View } from 'react-native'
 
 import ActionRow, { ActionRowProps } from '@/components/actions/ActionRow'
 import ListRow, { ListRowProps } from '@/components/actions/ListRow'
+import Divider from '@/components/shared/Divider'
 
 const ListRowsShowcase = () => {
   const dataListRows: ListRowProps[] = [
@@ -20,9 +21,25 @@ const ListRowsShowcase = () => {
 
   return (
     <View className="p-4 g-4">
-      <FlatList data={dataListRows} renderItem={({ item }) => <ListRow {...item} />} />
+      <View>
+        {dataListRows.map((item, index) => (
+          <>
+            {index !== 0 && <Divider />}
+            {/* eslint-disable-next-line react/no-array-index-key */}
+            <ListRow key={index} {...item} />
+          </>
+        ))}
+      </View>
 
-      <FlatList data={dataActionRows} renderItem={({ item }) => <ActionRow {...item} />} />
+      <View>
+        {dataActionRows.map((item, index) => (
+          <>
+            {index !== 0 && <Divider />}
+            {/* eslint-disable-next-line react/no-array-index-key */}
+            <ActionRow key={index} {...item} />
+          </>
+        ))}
+      </View>
     </View>
   )
 }


### PR DESCRIPTION
- implement `IconButton` with required `accessibilityLabel`
- add `forwardRef` to IconButton and to ActionRow - this may need revisit how we treat Pressable components
- resolves #60 

![image](https://github.com/bratislava/paas-mpa/assets/19418224/e800f52e-93ff-4ade-b901-d51d167887c2)
