### PR TITLE
[#27] implement TimeSelector

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -68,6 +68,7 @@ const RootLayout = () => {
       >
         <Stack.Screen name="vehicles/add-vehicle" options={{ presentation: 'modal' }} />
         <Stack.Screen name="purchase/choose-vehicle" options={{ presentation: 'modal' }} />
+        <Stack.Screen name="purchase/custom-time" options={{ presentation: 'modal' }} />
       </Stack>
     </SafeAreaProvider>
   )

--- a/app/examples/styleguide.tsx
+++ b/app/examples/styleguide.tsx
@@ -13,6 +13,7 @@ import ParkingCardsShowcase from '@/components/showcases/ParkingCardsShowcase'
 import SegmentBadgeShowcase from '@/components/showcases/SegmentBadgeShowcase'
 import SurfaceShowcase from '@/components/showcases/SurfaceShowcase'
 import TextInputShowcase from '@/components/showcases/TextInputShowcase'
+import TimeSelectorShowcase from '@/components/showcases/TimeSelectorShowcase'
 import TypographyShowcase from '@/components/showcases/TypographyShowcase'
 
 const StyleguideScreen = () => (
@@ -23,6 +24,7 @@ const StyleguideScreen = () => (
     <FieldShowcase />
     <SurfaceShowcase />
     <DividerShowcase />
+    <TimeSelectorShowcase />
     <CheckBoxShowcase />
     <ListRowsShowcase />
     <IconShowCase />

--- a/app/purchase/custom-time.tsx
+++ b/app/purchase/custom-time.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import TextInput from '@/components/inputs/TextInput'
+import Field from '@/components/shared/Field'
+import ScreenContent from '@/components/shared/ScreenContent'
+import ScreenView from '@/components/shared/ScreenView'
+import Typography from '@/components/shared/Typography'
+import { useTranslation } from '@/hooks/useTranslation'
+
+const Page = () => {
+  const t = useTranslation('PurchaseScreen')
+
+  return (
+    <ScreenView title={t('customParkingTimeTitle')}>
+      <ScreenContent>
+        <Typography>TODO set custom time after confirm</Typography>
+        <Typography>TODO datetime picker</Typography>
+        <Field label="Temporary field: custom time in minutes">
+          <TextInput keyboardType="numeric" />
+        </Field>
+      </ScreenContent>
+    </ScreenView>
+  )
+}
+
+export default Page

--- a/app/purchase/index.tsx
+++ b/app/purchase/index.tsx
@@ -1,11 +1,12 @@
 import BottomSheet, { BottomSheetView } from '@gorhom/bottom-sheet'
 import { Link, Stack, useLocalSearchParams } from 'expo-router'
 import React, { useRef } from 'react'
+import { ScrollView } from 'react-native'
 
 import PaymentGate from '@/components/controls/payment-methods/PaymentGate'
+import TimeSelector from '@/components/controls/TimeSelector'
 import VehicleField from '@/components/controls/vehicles/VehicleField'
 import SegmentBadge from '@/components/info/SegmentBadge'
-import TextInput from '@/components/inputs/TextInput'
 import Button from '@/components/shared/Button'
 import Divider from '@/components/shared/Divider'
 import Field from '@/components/shared/Field'
@@ -13,8 +14,8 @@ import FlexRow from '@/components/shared/FlexRow'
 import Panel from '@/components/shared/Panel'
 import PressableStyled from '@/components/shared/PressableStyled'
 import ScreenContent from '@/components/shared/ScreenContent'
-import ScreenView from '@/components/shared/ScreenView'
 import Typography from '@/components/shared/Typography'
+import { useTimeSelector } from '@/hooks/useTimeSelector'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useVehicles } from '@/hooks/useVehicles'
 
@@ -23,40 +24,42 @@ const PurchaseScreen = () => {
   const bottomSheetRef = useRef<BottomSheet>(null)
   const { licencePlate } = useLocalSearchParams()
   const { getVehicle, defaultVehicle } = useVehicles()
-
+  const { timeValue, setTimeValue } = useTimeSelector(60)
   const chosenVehicle =
     licencePlate && typeof licencePlate === 'string' ? getVehicle(licencePlate) : defaultVehicle
 
+  // TODO TimeSelector chips collapses when not in ScrollView - investigate
   return (
-    <ScreenView>
-      <Stack.Screen options={{ title: t('ticketPurchaseTitle') }} />
+    <>
+      <ScrollView>
+        <Stack.Screen options={{ title: t('title') }} />
 
-      <ScreenContent>
-        <Field label={t('segmentFieldLabel')} labelInsertArea={<SegmentBadge label="1048" />}>
-          <PressableStyled>
-            <Panel>
-              <FlexRow>
-                <Typography>Staré Mesto – Fazuľová</Typography>
-                <Typography variant="default-semibold">2,90</Typography>
-              </FlexRow>
-            </Panel>
-          </PressableStyled>
-        </Field>
+        <ScreenContent>
+          <Field label={t('segmentFieldLabel')} labelInsertArea={<SegmentBadge label="1048" />}>
+            <PressableStyled>
+              <Panel>
+                <FlexRow>
+                  <Typography>Staré Mesto – Fazuľová</Typography>
+                  <Typography variant="default-semibold">2,90</Typography>
+                </FlexRow>
+              </Panel>
+            </PressableStyled>
+          </Field>
 
-        <VehicleField vehicle={chosenVehicle} />
+          <VehicleField vehicle={chosenVehicle} />
 
-        <Field label={t('parkingTimeFieldLabel')}>
-          {/* TODO replace by proper field control */}
-          <TextInput keyboardType="numeric" />
-        </Field>
+          <Field label={t('parkingTimeFieldLabel')}>
+            <TimeSelector value={timeValue} onValueChange={setTimeValue} />
+          </Field>
 
-        <Field label={t('paymentMethodsFieldLabel')}>
-          {/* TODO replace by proper field control */}
-          <PressableStyled>
-            <PaymentGate />
-          </PressableStyled>
-        </Field>
-      </ScreenContent>
+          <Field label={t('paymentMethodsFieldLabel')}>
+            {/* TODO replace by proper field control */}
+            <PressableStyled>
+              <PaymentGate />
+            </PressableStyled>
+          </Field>
+        </ScreenContent>
+      </ScrollView>
 
       <BottomSheet ref={bottomSheetRef} enableDynamicSizing>
         <BottomSheetView className="p-5 pb-[50px] g-3">
@@ -77,7 +80,7 @@ const PurchaseScreen = () => {
           </Link>
         </BottomSheetView>
       </BottomSheet>
-    </ScreenView>
+    </>
   )
 }
 

--- a/components/controls/TimeSelector.tsx
+++ b/components/controls/TimeSelector.tsx
@@ -1,0 +1,111 @@
+import { Link } from 'expo-router'
+import React from 'react'
+import { View } from 'react-native'
+
+import Chip from '@/components/shared/Chip'
+import Divider from '@/components/shared/Divider'
+import FlexRow from '@/components/shared/FlexRow'
+import IconButton from '@/components/shared/IconButton'
+import Panel from '@/components/shared/Panel'
+import PressableStyled from '@/components/shared/PressableStyled'
+import Typography from '@/components/shared/Typography'
+import { useTranslation } from '@/hooks/useTranslation'
+import { formatMinutes } from '@/utils/formatMinutes'
+
+type Props = {
+  value: number // number of minutes
+  onValueChange: (value: number) => void
+}
+
+const TimeSelector = ({ value, onValueChange }: Props) => {
+  const t = useTranslation('TimeSelector')
+  // eslint-disable-next-line const-case/uppercase
+  const customTimeScreen = '/purchase/custom-time'
+
+  const addTime = () => {
+    onValueChange(value + 15)
+  }
+
+  const subtractTime = () => {
+    onValueChange(Math.max(0, value - 15))
+  }
+
+  const setTime = (minutes: number) => {
+    onValueChange(minutes)
+  }
+
+  const chipRow1 = [{ value: 15 }, { value: 30 }, { value: 45 }, { value: 60 }]
+  const chipRow2 = [{ value: 120 }, { value: 240 }, { value: 480 }]
+
+  return (
+    <Panel className="g-4">
+      <FlexRow cn="items-center">
+        <IconButton
+          variant="dark"
+          name="remove"
+          accessibilityLabel={t('subtractTimeButton')}
+          onPress={subtractTime}
+        />
+        <Link asChild href={customTimeScreen}>
+          <PressableStyled>
+            <Typography variant="h1">{formatMinutes(value)}</Typography>
+          </PressableStyled>
+        </Link>
+        <IconButton
+          variant="dark"
+          name="add"
+          accessibilityLabel={t('addTimeButton')}
+          onPress={addTime}
+        />
+      </FlexRow>
+      <View className="g-1">
+        <View className="flex-row g-1">
+          {chipRow1.map((chip) => {
+            return (
+              <PressableStyled
+                key={chip.value}
+                onPress={() => setTime(chip.value)}
+                className="flex-1"
+              >
+                <Chip label={formatMinutes(chip.value)} isActive={chip.value === value} />
+              </PressableStyled>
+            )
+          })}
+        </View>
+        <View className="flex-row g-1">
+          {chipRow2.map((chip) => {
+            return (
+              <PressableStyled
+                key={chip.value}
+                onPress={() => setTime(Number(chip.value))}
+                className="flex-1"
+              >
+                <Chip label={formatMinutes(chip.value)} isActive={chip.value === value} />
+              </PressableStyled>
+            )
+          })}
+
+          <Link asChild href={customTimeScreen}>
+            <PressableStyled className="flex-1">
+              <Chip label="Custom" />
+            </PressableStyled>
+          </Link>
+        </View>
+      </View>
+
+      <Divider />
+
+      <FlexRow>
+        <Typography variant="small">Valid until</Typography>
+
+        <Link asChild href={customTimeScreen}>
+          <PressableStyled>
+            <Typography variant="small-bold">12:00 TODO</Typography>
+          </PressableStyled>
+        </Link>
+      </FlexRow>
+    </Panel>
+  )
+}
+
+export default TimeSelector

--- a/components/controls/vehicles/VehicleField.tsx
+++ b/components/controls/vehicles/VehicleField.tsx
@@ -19,7 +19,7 @@ const VehicleField = ({ vehicle }: Props) => {
   const t = useTranslation('VehiclesScreen')
 
   return (
-    <Field label={t('vehicleFieldLabel')}>
+    <Field label={t('chooseVehicleFieldLabel')}>
       {/* TODO Link+Pressable */}
       <Link asChild href="/purchase/choose-vehicle">
         <PressableStyled>

--- a/components/shared/Chip.tsx
+++ b/components/shared/Chip.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx'
 import React from 'react'
-import { TouchableOpacity } from 'react-native'
+import { View } from 'react-native'
 
 import Typography from '@/components/shared/Typography'
 
@@ -12,17 +12,17 @@ type Props = {
 
 const Chip = ({ label, isActive, chipClassName }: Props) => {
   return (
-    <TouchableOpacity
+    <View
       className={clsx(
-        'rounded border p-3',
-        isActive ? 'border-dark bg-dark' : 'border-divider bg-transparent',
+        'flex-1 items-center justify-center rounded border p-3',
+        isActive ? 'border-dark bg-dark' : 'border-divider bg-white',
         chipClassName,
       )}
     >
-      <Typography variant="small-semibold" className={clsx(isActive ? 'text-white' : 'text-dark')}>
+      <Typography variant="small-bold" className={clsx(isActive ? 'text-white' : 'text-dark')}>
         {label}
       </Typography>
-    </TouchableOpacity>
+    </View>
   )
 }
 

--- a/components/showcases/TimeSelectorShowcase.tsx
+++ b/components/showcases/TimeSelectorShowcase.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { View } from 'react-native'
+
+import TimeSelector from '@/components/controls/TimeSelector'
+import { useTimeSelector } from '@/hooks/useTimeSelector'
+
+const TimeSelectorShowcase = () => {
+  const { timeValue, setTimeValue } = useTimeSelector(60)
+
+  return (
+    <View className="p-4 g-4">
+      <TimeSelector value={timeValue} onValueChange={setTimeValue} />
+    </View>
+  )
+}
+
+export default TimeSelectorShowcase

--- a/hooks/useTimeSelector.tsx
+++ b/hooks/useTimeSelector.tsx
@@ -1,0 +1,10 @@
+import { useState } from 'react'
+
+export const useTimeSelector = (defaultValue: number) => {
+  const [value, setValue] = useState<number>(defaultValue)
+
+  return {
+    timeValue: value,
+    setTimeValue: setValue,
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,11 +28,11 @@ module.exports = {
     // https://github.com/marklawlor/nativewind/issues/386
     g: ({ theme }) => theme('spacing'),
     fontSize: {
-      h1: ['1.5rem', '2rem'], // 24px / 32px
-      h2: ['1.25rem', '1.5rem'], // 20px / 24px
-      h3: ['1rem', '1.5rem'], // 16px / 24px
-      16: ['1rem', '1.5rem'], // 16px / 24px
-      14: ['0.875rem', '1.5rem'], // 14px / 24px
+      h1: ['24px', '32px'],
+      h2: ['20px', '24px'],
+      h3: ['16px', '24px'],
+      16: ['16px', '24px'],
+      14: ['14px', '24px'],
     },
     borderRadius: {
       none: '0',

--- a/translations/en.json
+++ b/translations/en.json
@@ -24,13 +24,14 @@
     "verifyYourEmailInfo": "TODO EN Poslali sme vám overovací e-mail na adresu: {{email}}. \n\nKliknite na overovacie tlačidlo v e-maily a potvrďte overenie. Po potvrdení nahráme všetky vaše parkovacie karty a zľavy do aplikácie."
   },
   "PurchaseScreen": {
-    "ticketPurchaseTitle": "Ticket purchase",
+    "title": "Ticket purchase",
     "segmentFieldLabel": "Segment",
-    "parkingTimeFieldLabel": "Parking time",
+    "parkingTimeFieldLabel": "Parking duration",
     "paymentMethodsFieldLabel": "Payment methods & Visitor cards",
     "addVehicle": "Add vehicle",
     "summary": "Summary",
-    "pay": "Pay"
+    "pay": "Pay",
+    "customParkingTimeTitle": "Custom time"
   },
   "VehiclesScreen": {
     "title": "Vehicles",
@@ -80,5 +81,9 @@
     },
     "validUntil": "Valid until",
     "remainingCredit": "Remaining credit"
+  },
+  "TimeSelector": {
+    "addTimeButton": "Add 15 minutes",
+    "subtractTimeButton": "Subtract 15 minutes"
   }
 }

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -24,13 +24,14 @@
     "verifyYourEmailInfo": "Poslali sme vám overovací e-mail na adresu: {{email}}. \n\nKliknite na overovacie tlačidlo v e-maily a potvrďte overenie. Po potvrdení nahráme všetky vaše parkovacie karty a zľavy do aplikácie."
   },
   "PurchaseScreen": {
-    "ticketPurchaseTitle": "Nákup lístka",
+    "title": "Nákup lístka",
     "segmentFieldLabel": "Segment",
     "parkingTimeFieldLabel": "Doba parkovania",
     "paymentMethodsFieldLabel": "Platobné metódy & Návštevnícke karty",
     "addVehicle": "Pridať vozidlo",
     "summary": "Celkom",
-    "pay": "Zaplatiť"
+    "pay": "Zaplatiť",
+    "customParkingTimeTitle": "Vlastný čas"
   },
   "VehiclesScreen": {
     "title": "Vozidlá",

--- a/utils/formatMinutes.tsx
+++ b/utils/formatMinutes.tsx
@@ -1,0 +1,9 @@
+export const formatMinutes = (minutes: number) => {
+  const hours = Math.floor(minutes / 60)
+  const minutesLeft = minutes % 60
+
+  return [
+    hours > 0 ? `${hours} h` : '',
+    hours > 0 && minutesLeft === 0 ? '' : `${minutesLeft} min`,
+  ].join(' ')
+}


### PR DESCRIPTION
TimeSelector with pre-defined time chips.

TODO:
- set custom time when entered on "Custom time" screen
- highlight "custom" chip when no other ships match the time value
- compute "valid until" information
- implement "Custom time" screen with datetime picker - now it has only simple text input (that does not pass the value anywhere).

Notes:
- Text seemed to be smaller in general than desired - units had to be changes to `px` instead of `rem`.
- Chips with label formatted by `formatMinutes` function are collapsed (with no label) when in simple `View`. In `ScrollView` it works. - needs investigation

![image](https://github.com/bratislava/paas-mpa/assets/19418224/50633023-da1f-49f5-b7dd-cd93da35cf51)
