### PR TITLE
Point detail BottomSheet

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -13,6 +13,7 @@ import {
 import Mapbox from '@rnmapbox/maps'
 import { SplashScreen, Stack } from 'expo-router'
 import { useEffect, useState } from 'react'
+import { NativeModules } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 
@@ -20,6 +21,13 @@ import { environment } from '@/environment'
 import colors from '@/tailwind.config.colors'
 
 SplashScreen.preventAutoHideAsync()
+
+const { UIManager } = NativeModules
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+if (UIManager.setLayoutAnimationEnabledExperimental)
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+  UIManager.setLayoutAnimationEnabledExperimental(true)
 
 const RootLayout = () => {
   const [mapboxLoaded, setMapboxLoaded] = useState(false)

--- a/app/examples/bottom-sheet.tsx
+++ b/app/examples/bottom-sheet.tsx
@@ -1,65 +1,49 @@
-import BottomSheet from '@gorhom/bottom-sheet'
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { useMemo } from 'react'
 
-import SegmentBadge from '@/components/info/SegmentBadge'
-import TextInput from '@/components/inputs/TextInput'
-import BottomSheetContent from '@/components/shared/BottomSheetContent'
-import Divider from '@/components/shared/Divider'
-import Field from '@/components/shared/Field'
-import FlexRow from '@/components/shared/FlexRow'
-import Panel from '@/components/shared/Panel'
-import ScreenView from '@/components/shared/ScreenView'
-import Typography from '@/components/shared/Typography'
+import MapPointBottomSheet from '@/components/map/MapPointBottomSheet'
+import { IconsEnum, KindsEnum } from '@/modules/map/constants'
+
+const BRANCH_EXAMPLE = {
+  Adresa: 'Primaciálne nám. 1, 811 01 Bratislava',
+  Miesto: 'Magistrát hl. mesta SR Bratislavy',
+  Navigacia:
+    'https://www.google.com/maps/place/Magistr%C3%A1t+hlavn%C3%A9ho+mesta+SR+Bratislavy/@48.1439423,17.1091824,234m/data=!3m3!1e3!4b1!5s0x476c89431d7c7795:0x4caf7acfb0ed99d7!4m5!3m4!1s0x476c89433d1bc761:0x6ad8016ef317f8f0!8m2!3d48.1439414!4d17.1097296',
+  Nazov: 'PAAS Centrum',
+  OBJECTID: 4,
+  Otvaracie_hodiny_en: 'Mo 8:30-17:00, Tu-Th 8:30-16:00, Fr 8:30-15:00',
+  Otvaracie_hodiny_sk: 'Po 8:30-17:00, Ut-Št 8:30-16:00, Pi 8:30-15:00',
+  icon: IconsEnum.branch,
+  kind: KindsEnum.branch,
+}
+
+const PARKING_LOT_EXAMPLE = {
+  Dojazdova_doba: '4 min',
+  Navigacia:
+    'https://www.google.com/maps/place/Parkovisko+%C4%8Cerny%C5%A1evsk%C3%A9ho/@48.1301808,17.1171949,220m/data=!3m1!1e3!4m14!1m8!3m7!1s0x0:0x73e7a623fba85a53!2zNDjCsDA3JzQ4LjkiTiAxN8KwMDcnMDEuNiJF!3b1!7e2!8m2!3d48.1302537!4d17.1171213!3m4!1s0x476c89d84e48ef8b',
+  Nazov_en: 'Parking lot Černyševského',
+  Nazov_sk: 'Záchytné parkovisko Černyševského',
+  OBJECTID: 7,
+  Pocet_parkovacich_miest: '59',
+  Povrch_en: 'parking lot',
+  Povrch_sk: 'parkovisko',
+  Prevadzkova_doba:
+    'V pracovné dni: Od 05:00-24:00 pre návštevníkov zadarmo. Od 00:00-05:00 len pre držiteľov rezidentskej karty.\nVíkendy: zadarmo.',
+  Stav_en: 'new',
+  Stav_sk: 'nové',
+  Typ_en: 'parking lot',
+  Typ_sk: 'parkovisko',
+  Verejna_doprava: '3, 84, 95, 99',
+  Vzdialenost: '>500 m',
+  icon: 'parking-lot',
+  kind: 'parking-lots',
+  web: 'ano',
+  zone: 'PE1',
+}
 
 const Page = () => {
-  const bottomSheetRef = useRef<BottomSheet>(null)
-  const snapPoints = useMemo(() => ['25%', '50%'], [])
+  const point = useMemo(() => BRANCH_EXAMPLE, [])
 
-  const [showSegmentDetail, setShowSegmentDetail] = useState(false)
-
-  const handleSheetChanges = useCallback((index: number) => {
-    if (index === 1) {
-      setShowSegmentDetail(true)
-    } else {
-      setShowSegmentDetail(false)
-    }
-    console.log('handleSheetChanges', index)
-  }, [])
-
-  return (
-    <ScreenView backgroundVariant="dots">
-      <BottomSheet
-        ref={bottomSheetRef}
-        index={0}
-        snapPoints={snapPoints}
-        onChange={handleSheetChanges}
-      >
-        <BottomSheetContent cn="g-5">
-          <Field label="Where are you parking?">
-            <TextInput />
-          </Field>
-          {showSegmentDetail && (
-            <>
-              <Panel className="g-4">
-                <FlexRow>
-                  <Typography>Fazuľová + Školská</Typography>
-                  <SegmentBadge label="1009" />
-                </FlexRow>
-                <Divider />
-                <FlexRow>
-                  <Typography variant="default-bold">2€ / h</Typography>
-                  <Typography variant="default-bold">Show details</Typography>
-                </FlexRow>
-              </Panel>
-              <Typography>
-                This is just a working example without proper styling and functionality.
-              </Typography>
-            </>
-          )}
-        </BottomSheetContent>
-      </BottomSheet>
-    </ScreenView>
-  )
+  return <MapPointBottomSheet point={point} />
 }
 
 export default Page

--- a/app/examples/bottom-sheet.tsx
+++ b/app/examples/bottom-sheet.tsx
@@ -16,6 +16,7 @@ const BRANCH_EXAMPLE = {
   kind: KindsEnum.branch,
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const PARKING_LOT_EXAMPLE = {
   Dojazdova_doba: '4 min',
   Navigacia:

--- a/app/examples/bottom-sheet.tsx
+++ b/app/examples/bottom-sheet.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 
 import MapPointBottomSheet from '@/components/map/MapPointBottomSheet'
-import { IconsEnum, KindsEnum } from '@/modules/map/constants'
+import { MapPointIconEnum, MapPointKindEnum } from '@/modules/map/constants'
 
 const BRANCH_EXAMPLE = {
   Adresa: 'Primaciálne nám. 1, 811 01 Bratislava',
@@ -12,8 +12,8 @@ const BRANCH_EXAMPLE = {
   OBJECTID: 4,
   Otvaracie_hodiny_en: 'Mo 8:30-17:00, Tu-Th 8:30-16:00, Fr 8:30-15:00',
   Otvaracie_hodiny_sk: 'Po 8:30-17:00, Ut-Št 8:30-16:00, Pi 8:30-15:00',
-  icon: IconsEnum.branch,
-  kind: KindsEnum.branch,
+  icon: MapPointIconEnum.branch,
+  kind: MapPointKindEnum.branch,
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -17,6 +17,7 @@ import { useDebouncedCallback } from 'use-debounce'
 
 import MapMarkers from '@/components/map/MapMarkers'
 import MapPin from '@/components/map/MapPin'
+import MapZones from '@/components/map/MapZones'
 import { CITY_BOUNDS, MAP_CENTER, MAP_INSETS } from '@/modules/map/constants'
 import { useLocation } from '@/modules/map/hooks/useLocation'
 import { useProcessedArcgisData } from '@/modules/map/hooks/useProcessedMapData'
@@ -24,8 +25,6 @@ import { useScreenCenter } from '@/modules/map/hooks/useScreenCenter'
 import { SelectedPoint, SelectedUdrZone } from '@/modules/map/types'
 import { colors } from '@/modules/map/utils/layer-styles/colors'
 import udrStyle from '@/modules/map/utils/layer-styles/visitors'
-
-import MapZones from './MapZones'
 
 type Props = {
   onZoneChange?: (feature: SelectedUdrZone) => void

--- a/components/map/MapMarkers.tsx
+++ b/components/map/MapMarkers.tsx
@@ -11,7 +11,7 @@ import {
   PPLusRImage,
   SellingPointImage,
 } from '@/assets/map/images'
-import { IconsEnum } from '@/modules/map/constants'
+import { MapPointIconEnum } from '@/modules/map/constants'
 import markersStyles from '@/modules/map/utils/layer-styles/markers'
 
 type Props = {
@@ -24,7 +24,7 @@ const MapMarkers = ({ markersData, onPointPress }: Props) => {
     string,
     FeatureCollection<Point, GeoJsonProperties | { icon: string }>,
   ][] = useMemo(() => {
-    return Object.values(IconsEnum).map((icon) => [
+    return Object.values(MapPointIconEnum).map((icon) => [
       icon,
       {
         ...markersData,
@@ -35,8 +35,9 @@ const MapMarkers = ({ markersData, onPointPress }: Props) => {
 
   const handlePointPress = useCallback(
     (event: OnPressEvent) => {
-      if (!event?.features || event.features.length === 0) return
-      onPointPress?.(event.features[0] as Feature<Point, GeoJsonProperties>)
+      if (event?.features && event?.features.length > 0) {
+        onPointPress?.(event.features[0] as Feature<Point, GeoJsonProperties>)
+      }
     },
     [onPointPress],
   )
@@ -45,13 +46,13 @@ const MapMarkers = ({ markersData, onPointPress }: Props) => {
     <>
       <Images
         images={{
-          [IconsEnum.parkomat]: ParkomatImage,
-          [IconsEnum.garage]: GarageImage,
-          [IconsEnum.branch]: SellingPointImage,
-          [IconsEnum.partner]: SellingPointImage,
-          [IconsEnum.pPlusR]: PPLusRImage,
-          [IconsEnum.parkingLot]: ParkingImage,
-          [IconsEnum.assistant]: AssistantImage,
+          [MapPointIconEnum.parkomat]: ParkomatImage,
+          [MapPointIconEnum.garage]: GarageImage,
+          [MapPointIconEnum.branch]: SellingPointImage,
+          [MapPointIconEnum.partner]: SellingPointImage,
+          [MapPointIconEnum.pPlusR]: PPLusRImage,
+          [MapPointIconEnum.parkingLot]: ParkingImage,
+          [MapPointIconEnum.assistant]: AssistantImage,
         }}
       />
       {markersDataByKind?.map(([icon, shape]) => (

--- a/components/map/MapMarkers.tsx
+++ b/components/map/MapMarkers.tsx
@@ -1,6 +1,7 @@
 import { Images, ShapeSource, SymbolLayer } from '@rnmapbox/maps'
-import { FeatureCollection, GeoJsonProperties, Point } from 'geojson'
-import { useMemo } from 'react'
+import { OnPressEvent } from '@rnmapbox/maps/lib/typescript/types/OnPressEvent'
+import { Feature, FeatureCollection, GeoJsonProperties, Point } from 'geojson'
+import { useCallback, useMemo } from 'react'
 
 import {
   AssistantImage,
@@ -15,9 +16,10 @@ import markersStyles from '@/modules/map/utils/layer-styles/markers'
 
 type Props = {
   markersData: FeatureCollection<Point, GeoJsonProperties | { icon: string }>
+  onPointPress?: (point: Feature<Point, GeoJsonProperties>) => void
 }
 
-const MapMarkers = ({ markersData }: Props) => {
+const MapMarkers = ({ markersData, onPointPress }: Props) => {
   const markersDataByKind: [
     string,
     FeatureCollection<Point, GeoJsonProperties | { icon: string }>,
@@ -30,6 +32,14 @@ const MapMarkers = ({ markersData }: Props) => {
       } satisfies FeatureCollection<Point, GeoJsonProperties | { icon: string }>,
     ])
   }, [markersData])
+
+  const handlePointPress = useCallback(
+    (event: OnPressEvent) => {
+      if (!event?.features || event.features.length === 0) return
+      onPointPress?.(event.features[0] as Feature<Point, GeoJsonProperties>)
+    },
+    [onPointPress],
+  )
 
   return (
     <>
@@ -51,6 +61,7 @@ const MapMarkers = ({ markersData }: Props) => {
           clusterRadius={50}
           clusterMaxZoomLevel={14}
           cluster
+          onPress={handlePointPress}
           key={icon}
         >
           <SymbolLayer

--- a/components/map/MapPointBottomSheet.tsx
+++ b/components/map/MapPointBottomSheet.tsx
@@ -1,12 +1,20 @@
-import BottomSheet from '@gorhom/bottom-sheet'
-import { forwardRef, useMemo } from 'react'
-import { View } from 'react-native'
+import BottomSheet, {
+  BottomSheetFooter,
+  BottomSheetFooterProps,
+  BottomSheetScrollView,
+} from '@gorhom/bottom-sheet'
+import { forwardRef, Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { LayoutAnimation, View } from 'react-native'
 
-import BottomSheetContent from '@/components/shared/BottomSheetContent'
 import { useTranslation } from '@/hooks/useTranslation'
 import { SelectedPoint } from '@/modules/map/types'
+import { normalizePoint } from '@/modules/map/utils/normalizePoint'
 
+import Button from '../shared/Button'
+import Divider from '../shared/Divider'
+import Field from '../shared/Field'
 import Icon from '../shared/Icon'
+import PressableStyled from '../shared/PressableStyled'
 import Typography from '../shared/Typography'
 
 type Props = {
@@ -15,19 +23,104 @@ type Props = {
 
 const MapPointBottomSheet = forwardRef<BottomSheet, Props>(({ point }, ref) => {
   const t = useTranslation('MapScreen.PointBottomSheet')
+  const [index, setIndex] = useState(-1)
 
-  const snapPoints = useMemo(() => ['50%', '80%'], [])
+  const snapPoints = useMemo(() => ['40%', '80%'], [])
 
-  console.log(point)
+  const localRef = useRef<BottomSheet>()
+
+  const setRefs: Ref<BottomSheet> = useCallback(
+    (passedRef: BottomSheet) => {
+      if (ref) {
+        if (ref instanceof Function) ref(passedRef)
+        // eslint-disable-next-line no-param-reassign
+        else ref.current = passedRef
+      }
+      localRef.current = passedRef
+    },
+    [ref],
+  )
+
+  const handleChange = useCallback((newIndex: number) => {
+    console.log(`change: ${newIndex}`)
+    const animation = LayoutAnimation.create(200, 'easeInEaseOut', 'opacity')
+    LayoutAnimation.configureNext(animation)
+    setIndex(newIndex)
+  }, [])
+
+  const np = normalizePoint(point)
+
+  const renderFooter = useCallback(
+    (props: BottomSheetFooterProps) => (
+      <BottomSheetFooter {...props}>
+        <View className="px-5 py-3">
+          <Button startIcon="directions" variant="primary" className="">
+            {t('getDirections')}
+          </Button>
+          <View className="h-[29px]" aria-hidden />
+        </View>
+      </BottomSheetFooter>
+    ),
+    [t],
+  )
+
+  const handleClose = useCallback(() => {
+    localRef.current?.close()
+  }, [])
+
+  useEffect(() => {
+    localRef.current?.collapse()
+  }, [point])
+
+  const expanded = index === 1
 
   return (
-    <BottomSheet ref={ref} enablePanDownToClose snapPoints={snapPoints}>
-      <BottomSheetContent cn="bg-white">
-        <View className="border-b-divider">
-          <Icon name="close" />
+    <BottomSheet
+      enablePanDownToClose
+      onChange={handleChange}
+      ref={setRefs}
+      snapPoints={snapPoints}
+      footerComponent={renderFooter}
+    >
+      <View className="flex-1">
+        <View className="flex-row justify-center border-b border-b-divider pb-3">
+          <View className="absolute bottom-4 left-0 ml-[10px]">
+            <PressableStyled onPress={handleClose}>
+              <Icon name="close" />
+            </PressableStyled>
+          </View>
           <Typography variant="h1">{t('title')}</Typography>
         </View>
-      </BottomSheetContent>
+        <BottomSheetScrollView className="bg-white" contentContainerStyle={{ paddingBottom: 80 }}>
+          <View>
+            <View className="px-5 pt-3">
+              <Field label={np.name ?? 'N/A'}>
+                <Typography>{np.kind}</Typography>
+              </Field>
+            </View>
+            <View className="px-5 py-5 g-4">
+              <View>
+                {np.address && (
+                  <Field label="Address">
+                    <Typography>{np.address}</Typography>
+                  </Field>
+                )}
+              </View>
+              {expanded &&
+                Object.keys(np)
+                  .filter((k) => !['address', 'name', 'navigation', 'kind'].includes(k))
+                  .map((k) => (
+                    <View key={k} className="g-4">
+                      <Divider />
+                      <Field label={k}>
+                        <Typography>{np[k as keyof typeof np]}</Typography>
+                      </Field>
+                    </View>
+                  ))}
+            </View>
+          </View>
+        </BottomSheetScrollView>
+      </View>
     </BottomSheet>
   )
 })

--- a/components/map/MapPointBottomSheet.tsx
+++ b/components/map/MapPointBottomSheet.tsx
@@ -1,0 +1,35 @@
+import BottomSheet from '@gorhom/bottom-sheet'
+import { forwardRef, useMemo } from 'react'
+import { View } from 'react-native'
+
+import BottomSheetContent from '@/components/shared/BottomSheetContent'
+import { useTranslation } from '@/hooks/useTranslation'
+import { SelectedPoint } from '@/modules/map/types'
+
+import Icon from '../shared/Icon'
+import Typography from '../shared/Typography'
+
+type Props = {
+  point: SelectedPoint
+}
+
+const MapPointBottomSheet = forwardRef<BottomSheet, Props>(({ point }, ref) => {
+  const t = useTranslation('MapScreen.PointBottomSheet')
+
+  const snapPoints = useMemo(() => ['50%', '80%'], [])
+
+  console.log(point)
+
+  return (
+    <BottomSheet ref={ref} enablePanDownToClose snapPoints={snapPoints}>
+      <BottomSheetContent cn="bg-white">
+        <View className="border-b-divider">
+          <Icon name="close" />
+          <Typography variant="h1">{t('title')}</Typography>
+        </View>
+      </BottomSheetContent>
+    </BottomSheet>
+  )
+})
+
+export default MapPointBottomSheet

--- a/components/map/MapPointBottomSheet.tsx
+++ b/components/map/MapPointBottomSheet.tsx
@@ -23,7 +23,7 @@ const MapPointBottomSheet = forwardRef<BottomSheet, Props>(({ point }, ref) => {
   const [index, setIndex] = useState(-1)
   const [footerHeight, setFooterHeight] = useState(0)
 
-  const np = useMemo(() => normalizePoint(point), [point])
+  const formattedMapPoint = useMemo(() => normalizePoint(point), [point])
 
   const snapPoints = useMemo(() => [375, '80%'], [])
 
@@ -49,17 +49,17 @@ const MapPointBottomSheet = forwardRef<BottomSheet, Props>(({ point }, ref) => {
 
   const renderFooter = useCallback(
     (props: BottomSheetFooterProps) => {
-      if (!np.navigation) return null
+      if (!formattedMapPoint.navigation) return null
 
       return (
         <NavigateBottomSheetFooter
           onLayout={(event) => setFooterHeight(event.nativeEvent.layout.height)}
-          navigationUrl={np.navigation}
+          navigationUrl={formattedMapPoint.navigation}
           {...props}
         />
       )
     },
-    [np.navigation],
+    [formattedMapPoint.navigation],
   )
 
   const handleClose = useCallback(() => {
@@ -70,7 +70,7 @@ const MapPointBottomSheet = forwardRef<BottomSheet, Props>(({ point }, ref) => {
     localRef.current?.collapse()
   }, [point])
 
-  const expanded = index === 1
+  const isExpanded = index === 1
 
   return (
     <BottomSheet
@@ -95,41 +95,43 @@ const MapPointBottomSheet = forwardRef<BottomSheet, Props>(({ point }, ref) => {
         >
           <View>
             <View className="px-5 pt-3">
-              <Field label={np.name} variant="h1">
-                <Typography>{t(`kinds.${np.kind}`)}</Typography>
+              <Field label={formattedMapPoint.name} variant="h1">
+                <Typography>{t(`kinds.${formattedMapPoint.kind}`)}</Typography>
               </Field>
             </View>
             <View className="px-5 pb-4 pt-5 g-4">
               <View>
-                {np.address && (
+                {formattedMapPoint.address && (
                   <Field label={t('fields.address')}>
-                    <Typography>{np.address}</Typography>
+                    <Typography>{formattedMapPoint.address}</Typography>
                   </Field>
                 )}
               </View>
-              {!expanded && (
-                <>
-                  {np.address && <Divider />}
-                  <View>
-                    {np.id && (
-                      <Field label="ID">
-                        <Typography>{np.id}</Typography>
-                      </Field>
-                    )}
-                  </View>
-                </>
-              )}
-              {expanded &&
-                Object.keys(np)
+              {isExpanded ? (
+                Object.keys(formattedMapPoint)
                   .filter((k) => !EXCLUDED_ATTRIBUTES.has(k))
                   .map((k) => (
                     <View key={k} className="g-4">
                       <Divider />
                       <Field label={t(`fields.${k}`)}>
-                        <Typography>{np[k as keyof typeof np]}</Typography>
+                        <Typography>
+                          {formattedMapPoint[k as keyof typeof formattedMapPoint]}
+                        </Typography>
                       </Field>
                     </View>
-                  ))}
+                  ))
+              ) : (
+                <>
+                  {formattedMapPoint.address && <Divider />}
+                  <View>
+                    {formattedMapPoint.id && (
+                      <Field label="ID">
+                        <Typography>{formattedMapPoint.id}</Typography>
+                      </Field>
+                    )}
+                  </View>
+                </>
+              )}
             </View>
           </View>
         </BottomSheetScrollView>

--- a/components/map/MapScreen.tsx
+++ b/components/map/MapScreen.tsx
@@ -3,10 +3,9 @@ import { useCallback, useRef, useState } from 'react'
 import { View } from 'react-native'
 
 import Map from '@/components/map/Map'
+import MapPointBottomSheet from '@/components/map/MapPointBottomSheet'
+import MapZoneBottomSheet from '@/components/map/MapZoneBottomSheet'
 import { SelectedPoint, SelectedUdrZone } from '@/modules/map/types'
-
-import MapPointBottomSheet from './MapPointBottomSheet'
-import MapZoneBottomSheet from './MapZoneBottomSheet'
 
 const MapScreen = () => {
   const [selectedZone, setSelectedZone] = useState<SelectedUdrZone | null>(null)

--- a/components/map/MapScreen.tsx
+++ b/components/map/MapScreen.tsx
@@ -23,7 +23,7 @@ const MapScreen = () => {
   const handlePointPress = useCallback(
     (zone: SelectedPoint) => {
       setSelectedPoint(zone)
-      zoneBottomSheetRef.current?.expand()
+      zoneBottomSheetRef.current?.snapToIndex(0)
     },
     [setSelectedPoint],
   )

--- a/components/map/MapScreen.tsx
+++ b/components/map/MapScreen.tsx
@@ -3,26 +3,36 @@ import { useCallback, useRef, useState } from 'react'
 import { View } from 'react-native'
 
 import Map from '@/components/map/Map'
-import { SelectedUdrZone } from '@/modules/map/types'
+import { SelectedPoint, SelectedUdrZone } from '@/modules/map/types'
 
+import MapPointBottomSheet from './MapPointBottomSheet'
 import MapZoneBottomSheet from './MapZoneBottomSheet'
 
 const MapScreen = () => {
   const [selectedZone, setSelectedZone] = useState<SelectedUdrZone>(null)
+  const [selectedPoint, setSelectedPoint] = useState<SelectedPoint>(null)
   const zoneBottomSheetRef = useRef<BottomSheet>(null)
+  const pointBottomSheetRef = useRef<BottomSheet>(null)
   const handleZoneChange = useCallback(
-    (content: SelectedUdrZone) => {
-      setSelectedZone(content)
-      console.log(content)
+    (zone: SelectedUdrZone) => {
+      setSelectedZone(zone)
       zoneBottomSheetRef.current?.snapToIndex(0)
     },
     [setSelectedZone],
   )
+  const handlePointPress = useCallback(
+    (zone: SelectedPoint) => {
+      setSelectedPoint(zone)
+      zoneBottomSheetRef.current?.expand()
+    },
+    [setSelectedPoint],
+  )
 
   return (
     <View className="flex-1 items-stretch">
-      <Map onZoneChange={handleZoneChange} />
+      <Map onZoneChange={handleZoneChange} onPointPress={handlePointPress} />
       <MapZoneBottomSheet ref={zoneBottomSheetRef} zone={selectedZone} />
+      <MapPointBottomSheet ref={pointBottomSheetRef} point={selectedPoint} />
     </View>
   )
 }

--- a/components/map/MapScreen.tsx
+++ b/components/map/MapScreen.tsx
@@ -9,8 +9,8 @@ import MapPointBottomSheet from './MapPointBottomSheet'
 import MapZoneBottomSheet from './MapZoneBottomSheet'
 
 const MapScreen = () => {
-  const [selectedZone, setSelectedZone] = useState<SelectedUdrZone>(null)
-  const [selectedPoint, setSelectedPoint] = useState<SelectedPoint>(null)
+  const [selectedZone, setSelectedZone] = useState<SelectedUdrZone | null>(null)
+  const [selectedPoint, setSelectedPoint] = useState<SelectedPoint | null>(null)
   const zoneBottomSheetRef = useRef<BottomSheet>(null)
   const pointBottomSheetRef = useRef<BottomSheet>(null)
   const handleZoneChange = useCallback(
@@ -32,7 +32,7 @@ const MapScreen = () => {
     <View className="flex-1 items-stretch">
       <Map onZoneChange={handleZoneChange} onPointPress={handlePointPress} />
       <MapZoneBottomSheet ref={zoneBottomSheetRef} zone={selectedZone} />
-      <MapPointBottomSheet ref={pointBottomSheetRef} point={selectedPoint} />
+      {selectedPoint && <MapPointBottomSheet ref={pointBottomSheetRef} point={selectedPoint} />}
     </View>
   )
 }

--- a/components/map/MapZoneBottomSheet.tsx
+++ b/components/map/MapZoneBottomSheet.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from '@/hooks/useTranslation'
 import { SelectedUdrZone } from '@/modules/map/types'
 
 type Props = {
-  zone: SelectedUdrZone
+  zone: SelectedUdrZone | null
 }
 
 const MapZoneBottomSheet = forwardRef<BottomSheet, Props>(({ zone }, ref) => {

--- a/components/map/MapZoneBottomSheet.tsx
+++ b/components/map/MapZoneBottomSheet.tsx
@@ -34,7 +34,7 @@ const MapZoneBottomSheet = forwardRef<BottomSheet, Props>(({ zone }, ref) => {
             <Field label={t('MapScreen.ZoneBottomSheet.title')}>
               <TextInput />
             </Field>
-            {zone && (
+            {zone ? (
               <Panel className="g-4">
                 <FlexRow>
                   <Typography>{zone.Nazov}</Typography>
@@ -61,7 +61,7 @@ const MapZoneBottomSheet = forwardRef<BottomSheet, Props>(({ zone }, ref) => {
                   </Link>
                 </FlexRow>
               </Panel>
-            )}
+            ) : null}
           </View>
           {zone ? (
             <Button variant="primary">{t('Navigation.continue')}</Button>

--- a/components/map/MapZoneBottomSheet.tsx
+++ b/components/map/MapZoneBottomSheet.tsx
@@ -31,7 +31,7 @@ const MapZoneBottomSheet = forwardRef<BottomSheet, Props>(({ zone }, ref) => {
       <BottomSheetContent cn="bg-white">
         <View className="bg-white g-3">
           <View className="g-2">
-            <Field label={t('MapScreen.BottomSheet.title')}>
+            <Field label={t('MapScreen.ZoneBottomSheet.title')}>
               <TextInput />
             </Field>
             {zone && (
@@ -53,7 +53,7 @@ const MapZoneBottomSheet = forwardRef<BottomSheet, Props>(({ zone }, ref) => {
                     <PressableStyled>
                       <View className="flex-row">
                         <Typography variant="default-bold">
-                          {t('MapScreen.BottomSheet.showDetails')}
+                          {t('MapScreen.ZoneBottomSheet.showDetails')}
                         </Typography>
                         <Icon name="expand-more" />
                       </View>
@@ -67,7 +67,7 @@ const MapZoneBottomSheet = forwardRef<BottomSheet, Props>(({ zone }, ref) => {
             <Button variant="primary">{t('Navigation.continue')}</Button>
           ) : (
             <Panel className="bg-warning-light g-2">
-              <Typography>{t('MapScreen.BottomSheet.noZoneSelected')}</Typography>
+              <Typography>{t('MapScreen.ZoneBottomSheet.noZoneSelected')}</Typography>
             </Panel>
           )}
         </View>

--- a/components/map/NavigateBottomSheetFooter.tsx
+++ b/components/map/NavigateBottomSheetFooter.tsx
@@ -1,0 +1,32 @@
+import { BottomSheetFooter, BottomSheetFooterProps } from '@gorhom/bottom-sheet'
+import * as Linking from 'expo-linking'
+import { useCallback } from 'react'
+import { View, ViewProps } from 'react-native'
+
+import Button from '@/components/shared/Button'
+import { useTranslation } from '@/hooks/useTranslation'
+
+type Props = BottomSheetFooterProps & {
+  onLayout: ViewProps['onLayout']
+  navigationUrl: string
+}
+
+const NavigateBottomSheetFooter = ({ onLayout, navigationUrl, ...restProps }: Props) => {
+  const t = useTranslation('MapScreen.PointBottomSheet')
+  const handlePress = useCallback(() => {
+    Linking.openURL(navigationUrl).catch((error) => console.warn(error))
+  }, [navigationUrl])
+
+  return (
+    <BottomSheetFooter {...restProps}>
+      <View onLayout={onLayout} className="px-5 pb-3">
+        <Button startIcon="directions" variant="primary" className="" onPress={handlePress}>
+          {t('getDirections')}
+        </Button>
+        <View className="h-[29px]" aria-hidden />
+      </View>
+    </BottomSheetFooter>
+  )
+}
+
+export default NavigateBottomSheetFooter

--- a/components/shared/Field.tsx
+++ b/components/shared/Field.tsx
@@ -1,21 +1,22 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { View } from 'react-native'
 
-import Typography from '@/components/shared/Typography'
+import Typography, { TypographyProps } from '@/components/shared/Typography'
 
 type Props = {
   label: string
   labelInsertArea?: ReactNode
   children: ReactNode
   errorMessage?: string
+  variant?: TypographyProps['variant']
 }
 // TODO associate control with label
 
-const Field = ({ label, children, labelInsertArea, errorMessage }: Props) => {
+const Field = ({ label, children, labelInsertArea, errorMessage, variant }: Props) => {
   return (
     <View className="g-1">
       <View className="flex-row g-6">
-        <Typography variant="default-bold" className="grow">
+        <Typography variant={variant ?? 'default-bold'} className="grow">
           {label}
         </Typography>
         {labelInsertArea || null}

--- a/components/shared/Field.tsx
+++ b/components/shared/Field.tsx
@@ -12,11 +12,17 @@ type Props = {
 }
 // TODO associate control with label
 
-const Field = ({ label, children, labelInsertArea, errorMessage, variant }: Props) => {
+const Field = ({
+  label,
+  children,
+  labelInsertArea,
+  errorMessage,
+  variant = 'default-bold',
+}: Props) => {
   return (
     <View className="g-1">
       <View className="flex-row g-6">
-        <Typography variant={variant ?? 'default-bold'} className="grow">
+        <Typography variant={variant} className="grow">
           {label}
         </Typography>
         {labelInsertArea || null}

--- a/components/shared/Typography.tsx
+++ b/components/shared/Typography.tsx
@@ -1,8 +1,7 @@
 import { clsx } from 'clsx'
-import React from 'react'
 import { Text as TextNative, TextProps } from 'react-native'
 
-type Props = TextProps & {
+export type TypographyProps = TextProps & {
   variant?:
     | 'h1'
     | 'h2'
@@ -16,7 +15,7 @@ type Props = TextProps & {
     | 'button'
 }
 
-const Typography = ({ variant = 'default', children, className, ...rest }: Props) => {
+const Typography = ({ variant = 'default', children, className, ...rest }: TypographyProps) => {
   return (
     <TextNative
       className={clsx(

--- a/modules/map/constants.ts
+++ b/modules/map/constants.ts
@@ -6,13 +6,13 @@ export const MAP_INSETS = {
   left: 10,
 }
 
-export enum LayersEnum {
+export enum MapLayerEnum {
   zones = 'zones',
   visitors = 'visitors',
   residents = 'residents',
 }
 
-export enum IconsEnum {
+export enum MapPointIconEnum {
   assistant = 'assistant',
   branch = 'branch',
   parkomat = 'parkomat',
@@ -22,7 +22,7 @@ export enum IconsEnum {
   parkingLot = 'parking-lot',
 }
 
-export enum KindsEnum {
+export enum MapPointKindEnum {
   assistant = 'assistants',
   branch = 'branches',
   parkomat = 'parkomats',

--- a/modules/map/types.ts
+++ b/modules/map/types.ts
@@ -127,7 +127,8 @@ export type ParkingLotPoint = SelectedPoint & {
 }
 
 export type NormalizedPoint = {
-  name?: string
+  id: number
+  name: string
   navigation?: string
   openingHours?: string
   kind: KindsEnum

--- a/modules/map/types.ts
+++ b/modules/map/types.ts
@@ -25,32 +25,133 @@ export type SelectedUdrZone = {
   layer: string // "visitors"
   vikendy_a_sviatky: number // 1
   web: string // "ano"
-} | null
+}
 
-// "Adresa": "Primaciálne nám. 1, 811 01 Bratislava", "Miesto": "Magistrát hl. mesta SR Bratislavy", "Navigacia": "https://www.google.com/maps/place/Magistr%C3%A1t+hlavn%C3%A9ho+mesta+SR+Bratislavy/@48.1439423,17.1091824,234m/data=!3m3!1e3!4b1!5s0x476c89431d7c7795:0x4caf7acfb0ed99d7!4m5!3m4!1s0x476c89433d1bc761:0x6ad8016ef317f8f0!8m2!3d48.1439414!4d17.1097296", "Nazov": "PAAS Centrum", "OBJECTID": 4, "Otvaracie_hodiny_en": "Mo 8:30-17:00, Tu-Th 8:30-16:00, Fr 8:30-15:00", "Otvaracie_hodiny_sk": "Po 8:30-17:00, Ut-Št 8:30-16:00, Pi 8:30-15:00", "icon": "branch", "kind": "branches"
+export type SelectedPoint = {
+  Navigacia: string // "https://www.google.com/maps/place/Magistr%C3%A1t+hlavn%C3%A9ho+mesta+SR+Bratislavy/@48.1439423,17.1091824,234m/data=!3m3!1e3!4b1!5s0x476c89431d7c7795:0x4caf7acfb0ed99d7!4m5!3m4!1s0x476c89433d1bc761:0x6ad8016ef317f8f0!8m2!3d48.1439414!4d17.1097296"
+  icon: IconsEnum
+  kind: KindsEnum
+}
 
-// "Navigacia": "https://goo.gl/maps/FqPh8De9v3E2DjV48", "Nazov": "Talks kaviareň ", "OBJECTID": 63, "Otvaracie_hodiny_en": "Mo-Th 7:15-18:00 Fr 7:15-19:00 Sa 9:00-19:00 Su 10:00-18:00", "Otvaracie_hodiny_sk": "Po-Št 7:15-18:00 Pi 7:15-19:00 So 9:00-19:00 Ne 10:00-18:00", "Predajne_miesto": "Talks kaviareň ", "adresa": "Jesenského 4", "icon": "partner", "kind": "partners", "web": "ano"
-
-// "Datum_osadenia_en": "31.07.2023", "Datum_osadenia_sk": "31.07.2023", "Lokalita": "Rigeleho x Paulínyho", "OBJECTID": 162, "Parkomat_ID": "P0076", "Rezidentska_zona": "SM0", "UDR": 1015, "Web": "ano", "icon": "parkomat", "kind": "parkomats"
-
-// "Adresa": "Námestie Martina Benku", "Informacia_NPK_en": "Visitor parking fee: weekdays from 8am-6pm - €1.80/h, weekdays from 6pm-8am + weekends and holidays - €1.20/h.", "Informacia_NPK_sk": "Návštevnícke parkovné: pracovné dni od 08:00-18:00 - 1,80 €/h., pracovné dni od 18:00-08:00 + víkendy a sviatky - 1,20 €/h. ", "Informacia_RPK_en": "For SM1 resident parking card holders - weekdays 5pm-8am + weekends and holidays are free.", "Informacia_RPK_sk": "Pre držiteľov rezidentskej parkovacej karty SM1 - pracovné dni 17:00-08:00 + víkendy a sviatky zadarmo.", "Navigacia": "https://www.google.com/maps/place/Podzemn%C3%A9+parkovisko/@48.1531608,17.1220751,166m/data=!3m1!1e3!4m5!3m4!1s0x476c8997d28106c9:0x364bf343a9111eb6!8m2!3d48.1532471!4d17.1220575", "Nazov_en": "Underground garage Krížna", "Nazov_sk": "Podzemná garáž Krížna", "OBJECTID": 23, "Povrch_en": "underground parking", "Povrch_sk": "podzemná garáž", "Prevadzkova_doba": "Nonstop", "Stav_en": "existing", "Stav_sk": "existujúce", "Typ_en": "garage", "Typ_sk": "garáž", "icon": "garage", "kind": "garages", "web": "ano", "zone": "SM1"
-
-// "Dojazdova_doba": "23 min", "Navigacia": "https://www.google.com/maps/@48.176567,17.0643259,57m/data=!3m1!1e3", "Nazov_en": "P+R Tesco Lamač", "Nazov_sk": "P+R Tesco Lamač", "OBJECTID": 26, "Pocet_parkovacich_miest": "33", "Povrch_en": "parking lot", "Povrch_sk": "parkovisko", "Prevadzkova_doba": "Neobmedzene", "Stav_en": "existing", "Stav_sk": "existujúce", "Typ_en": "P+R", "Typ_sk": "P+R", "Verejna_doprava": "20, 37, 45, 63, 130", "Vzdialenost": "<100 m", "icon": "p-plus-r", "kind": "p-plus-r", "web": "ano"
-
-// "Dojazdova_doba": "4 min", "Navigacia": "https://www.google.com/maps/place/Parkovisko+%C4%8Cerny%C5%A1evsk%C3%A9ho/@48.1301808,17.1171949,220m/data=!3m1!1e3!4m14!1m8!3m7!1s0x0:0x73e7a623fba85a53!2zNDjCsDA3JzQ4LjkiTiAxN8KwMDcnMDEuNiJF!3b1!7e2!8m2!3d48.1302537!4d17.1171213!3m4!1s0x476c89d84e48ef8b", "Nazov_en": "Parking lot Černyševského", "Nazov_sk": "Záchytné parkovisko Černyševského", "OBJECTID": 7, "Pocet_parkovacich_miest": "59", "Povrch_en": "parking lot", "Povrch_sk": "parkovisko", "Prevadzkova_doba": "V pracovné dni: Od 05:00-24:00 pre návštevníkov zadarmo. Od 00:00-05:00 len pre držiteľov rezidentskej karty.\nVíkendy: zadarmo.", "Stav_en": "new", "Stav_sk": "nové", "Typ_en": "parking lot", "Typ_sk": "parkovisko", "Verejna_doprava": "3, 84, 95, 99", "Vzdialenost": ">500 m", "icon": "parking-lot", "kind": "parking-lots", "web": "ano", "zone": "PE1"
-
-export type SelectedPoint = { Navigacia: string; icon: IconsEnum; kind: KindsEnum } | null
-
-export type BranchPoint = SelectedPoint & { Nazov: string; Adresa: string; kind: KindsEnum.branch }
+export type BranchPoint = SelectedPoint & {
+  Adresa: string // "Primaciálne nám. 1, 811 01 Bratislava"
+  Miesto: string // "Magistrát hl. mesta SR Bratislavy"
+  Nazov: string // "PAAS Centrum"
+  OBJECTID: number // 4
+  Otvaracie_hodiny_en: string // "Mo 8:30-17:00, Tu-Th 8:30-16:00, Fr 8:30-15:00"
+  Otvaracie_hodiny_sk: string // "Po 8:30-17:00, Ut-Št 8:30-16:00, Pi 8:30-15:00"
+}
 
 export type PartnerPoint = SelectedPoint & {
-  Nazov: string
-  adresa: string
-  kind: KindsEnum.partner
+  adresa: string // "Jesenského 4"
+  Miesto: string // "Magistrát hl. mesta SR Bratislavy"
+  Nazov: string // "Talks kaviareň "
+  OBJECTID: number // 63
+  Otvaracie_hodiny_en: string // "Mo-Th 7:15-18:00 Fr 7:15-19:00 Sa 9:00-19:00 Su 10:00-18:00"
+  Otvaracie_hodiny_sk: string // "Otvaracie_hodiny_sk": "Po-Št 7:15-18:00 Pi 7:15-19:00 So 9:00-19:00 Ne 10:00-18:00"
+  Predajne_miesto: string // "Talks kaviareň"
+  web?: string // "ano"
 }
+
+export type ParkomatPoint = SelectedPoint & {
+  Datum_osadenia_en: string // '31.07.2023'
+  Datum_osadenia_sk: string // '31.07.2023'
+  Lokalita: string // 'Rigeleho x Paulínyho'
+  OBJECTID: number // 162
+  Parkomat_ID: string // 'P0076'
+  Rezidentska_zona: string // 'SM0'
+  UDR: number // 1015
+  Web: string // 'ano'
+  Navigacia: never
+}
+
 export type GaragePoint = SelectedPoint & {
-  Nazov_en: string
-  Nazov_sk: string
-  Adresa: string
-  kind: KindsEnum.partner
+  Adresa: string // "Námestie Martina Benku"
+  Informacia_NPK_en: string // "Visitor parking fee: weekdays from 8am-6pm - €1.80/h, weekdays from 6pm-8am + weekends and holidays - €1.20/h."
+  Informacia_NPK_sk: string // "Návštevnícke parkovné: pracovné dni od 08:00-18:00 - 1,80 €/h., pracovné dni od 18:00-08:00 + víkendy a sviatky - 1,20 €/h. "
+  Informacia_RPK_en: string // "For SM1 resident parking card holders - weekdays 5pm-8am + weekends and holidays are free."
+  Informacia_RPK_sk: string // "Pre držiteľov rezidentskej parkovacej karty SM1 - pracovné dni 17:00-08:00 + víkendy a sviatky zadarmo."
+  Nazov_en: string // "Underground garage Krížna"
+  Nazov_sk: string // "Podzemná garáž Krížna"
+  OBJECTID: number // 23
+  Povrch_en: string // "underground parking"
+  Povrch_sk: string // "podzemná garáž"
+  Prevadzkova_doba: string // "Nonstop"
+  Stav_en: string // "existing"
+  Stav_sk: string // "existujúce"
+  Typ_en: string // "garage"
+  Typ_sk: string // "garáž"
+  web?: string // Optional field
+  zone: string // "SM1"
+}
+
+export type PPlusRPoinit = SelectedPoint & {
+  Dojazdova_doba: string // "23 min"
+  Nazov_en: string // "P+R Tesco Lamač"
+  Nazov_sk: string // "P+R Tesco Lamač"
+  OBJECTID: number // 26
+  Pocet_parkovacich_miest: string // "33"
+  Povrch_en: string // "parking lot"
+  Povrch_sk: string // "parkovisko"
+  Prevadzkova_doba: string // "Neobmedzene"
+  Stav_en: string // "existing"
+  Stav_sk: string // "existujúce"
+  Typ_en: string // "P+R"
+  Typ_sk: string // "P+R"
+  Verejna_doprava: string // "20, 37, 45, 63, 130"
+  Vzdialenost: string // "<100 m"
+  web?: string // Optional field
+  icon: string // "p-plus-r"
+  kind: string // "p-plus-r"
+}
+
+export type ParkingLotPoint = SelectedPoint & {
+  Dojazdova_doba: string // "4 min"
+  Nazov_en: string // "Parking lot Černyševského"
+  Nazov_sk: string // "Záchytné parkovisko Černyševského"
+  OBJECTID: number // 7
+  Pocet_parkovacich_miest: string // "59"
+  Povrch_en: string // "parking lot"
+  Povrch_sk: string // "parkovisko"
+  Prevadzkova_doba: string // "V pracovné dni: Od 05:00-24:00 pre návštevníkov zadarmo. Od 00:00-05:00 len pre držiteľov rezidentskej karty.\nVíkendy: zadarmo."
+  Stav_en: string // "new"
+  Stav_sk: string // "nové"
+  Typ_en: string // "parking lot"
+  Typ_sk: string // "parkovisko"
+  Verejna_doprava: string // "3, 84, 95, 99"
+  Vzdialenost: string // ">500 m"
+  web?: string // Optional field
+  icon: string // "parking-lot"
+  kind: string // "parking-lots"
+  zone: string // "PE1"
+}
+
+export type NormalizedPoint = {
+  name?: string
+  navigation?: string
+  openingHours?: string
+  kind: KindsEnum
+  address?: string
+  parkingSpotCount?: number
+  publicTransportLines?: string
+  distanceToCenter?: string
+  distanceToPublicTransport?: string
+}
+
+type PointTypes = {
+  [KindsEnum.assistant]: SelectedPoint & { kind: KindsEnum.assistant }
+  [KindsEnum.branch]: BranchPoint
+  [KindsEnum.parkomat]: ParkomatPoint
+  [KindsEnum.partner]: PartnerPoint
+  [KindsEnum.pPlusR]: PPlusRPoinit
+  [KindsEnum.garage]: GaragePoint
+  [KindsEnum.parkingLot]: ParkingLotPoint
+}
+
+// Type guard function using conditional types
+export function isPointOfType<T extends KindsEnum>(
+  point: SelectedPoint,
+  kind: T,
+): point is PointTypes[T] {
+  return point?.kind === kind
 }

--- a/modules/map/types.ts
+++ b/modules/map/types.ts
@@ -1,5 +1,7 @@
 /* eslint-disable babel/camelcase */
 
+import { IconsEnum, KindsEnum } from './constants'
+
 export type SelectedUdrZone = {
   Nazov: string
   Zakladna_cena: number // 2
@@ -23,6 +25,32 @@ export type SelectedUdrZone = {
   layer: string // "visitors"
   vikendy_a_sviatky: number // 1
   web: string // "ano"
-
-  type: 'zone' | 'point'
 } | null
+
+// "Adresa": "Primaciálne nám. 1, 811 01 Bratislava", "Miesto": "Magistrát hl. mesta SR Bratislavy", "Navigacia": "https://www.google.com/maps/place/Magistr%C3%A1t+hlavn%C3%A9ho+mesta+SR+Bratislavy/@48.1439423,17.1091824,234m/data=!3m3!1e3!4b1!5s0x476c89431d7c7795:0x4caf7acfb0ed99d7!4m5!3m4!1s0x476c89433d1bc761:0x6ad8016ef317f8f0!8m2!3d48.1439414!4d17.1097296", "Nazov": "PAAS Centrum", "OBJECTID": 4, "Otvaracie_hodiny_en": "Mo 8:30-17:00, Tu-Th 8:30-16:00, Fr 8:30-15:00", "Otvaracie_hodiny_sk": "Po 8:30-17:00, Ut-Št 8:30-16:00, Pi 8:30-15:00", "icon": "branch", "kind": "branches"
+
+// "Navigacia": "https://goo.gl/maps/FqPh8De9v3E2DjV48", "Nazov": "Talks kaviareň ", "OBJECTID": 63, "Otvaracie_hodiny_en": "Mo-Th 7:15-18:00 Fr 7:15-19:00 Sa 9:00-19:00 Su 10:00-18:00", "Otvaracie_hodiny_sk": "Po-Št 7:15-18:00 Pi 7:15-19:00 So 9:00-19:00 Ne 10:00-18:00", "Predajne_miesto": "Talks kaviareň ", "adresa": "Jesenského 4", "icon": "partner", "kind": "partners", "web": "ano"
+
+// "Datum_osadenia_en": "31.07.2023", "Datum_osadenia_sk": "31.07.2023", "Lokalita": "Rigeleho x Paulínyho", "OBJECTID": 162, "Parkomat_ID": "P0076", "Rezidentska_zona": "SM0", "UDR": 1015, "Web": "ano", "icon": "parkomat", "kind": "parkomats"
+
+// "Adresa": "Námestie Martina Benku", "Informacia_NPK_en": "Visitor parking fee: weekdays from 8am-6pm - €1.80/h, weekdays from 6pm-8am + weekends and holidays - €1.20/h.", "Informacia_NPK_sk": "Návštevnícke parkovné: pracovné dni od 08:00-18:00 - 1,80 €/h., pracovné dni od 18:00-08:00 + víkendy a sviatky - 1,20 €/h. ", "Informacia_RPK_en": "For SM1 resident parking card holders - weekdays 5pm-8am + weekends and holidays are free.", "Informacia_RPK_sk": "Pre držiteľov rezidentskej parkovacej karty SM1 - pracovné dni 17:00-08:00 + víkendy a sviatky zadarmo.", "Navigacia": "https://www.google.com/maps/place/Podzemn%C3%A9+parkovisko/@48.1531608,17.1220751,166m/data=!3m1!1e3!4m5!3m4!1s0x476c8997d28106c9:0x364bf343a9111eb6!8m2!3d48.1532471!4d17.1220575", "Nazov_en": "Underground garage Krížna", "Nazov_sk": "Podzemná garáž Krížna", "OBJECTID": 23, "Povrch_en": "underground parking", "Povrch_sk": "podzemná garáž", "Prevadzkova_doba": "Nonstop", "Stav_en": "existing", "Stav_sk": "existujúce", "Typ_en": "garage", "Typ_sk": "garáž", "icon": "garage", "kind": "garages", "web": "ano", "zone": "SM1"
+
+// "Dojazdova_doba": "23 min", "Navigacia": "https://www.google.com/maps/@48.176567,17.0643259,57m/data=!3m1!1e3", "Nazov_en": "P+R Tesco Lamač", "Nazov_sk": "P+R Tesco Lamač", "OBJECTID": 26, "Pocet_parkovacich_miest": "33", "Povrch_en": "parking lot", "Povrch_sk": "parkovisko", "Prevadzkova_doba": "Neobmedzene", "Stav_en": "existing", "Stav_sk": "existujúce", "Typ_en": "P+R", "Typ_sk": "P+R", "Verejna_doprava": "20, 37, 45, 63, 130", "Vzdialenost": "<100 m", "icon": "p-plus-r", "kind": "p-plus-r", "web": "ano"
+
+// "Dojazdova_doba": "4 min", "Navigacia": "https://www.google.com/maps/place/Parkovisko+%C4%8Cerny%C5%A1evsk%C3%A9ho/@48.1301808,17.1171949,220m/data=!3m1!1e3!4m14!1m8!3m7!1s0x0:0x73e7a623fba85a53!2zNDjCsDA3JzQ4LjkiTiAxN8KwMDcnMDEuNiJF!3b1!7e2!8m2!3d48.1302537!4d17.1171213!3m4!1s0x476c89d84e48ef8b", "Nazov_en": "Parking lot Černyševského", "Nazov_sk": "Záchytné parkovisko Černyševského", "OBJECTID": 7, "Pocet_parkovacich_miest": "59", "Povrch_en": "parking lot", "Povrch_sk": "parkovisko", "Prevadzkova_doba": "V pracovné dni: Od 05:00-24:00 pre návštevníkov zadarmo. Od 00:00-05:00 len pre držiteľov rezidentskej karty.\nVíkendy: zadarmo.", "Stav_en": "new", "Stav_sk": "nové", "Typ_en": "parking lot", "Typ_sk": "parkovisko", "Verejna_doprava": "3, 84, 95, 99", "Vzdialenost": ">500 m", "icon": "parking-lot", "kind": "parking-lots", "web": "ano", "zone": "PE1"
+
+export type SelectedPoint = { Navigacia: string; icon: IconsEnum; kind: KindsEnum } | null
+
+export type BranchPoint = SelectedPoint & { Nazov: string; Adresa: string; kind: KindsEnum.branch }
+
+export type PartnerPoint = SelectedPoint & {
+  Nazov: string
+  adresa: string
+  kind: KindsEnum.partner
+}
+export type GaragePoint = SelectedPoint & {
+  Nazov_en: string
+  Nazov_sk: string
+  Adresa: string
+  kind: KindsEnum.partner
+}

--- a/modules/map/types.ts
+++ b/modules/map/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable babel/camelcase */
 
-import { IconsEnum, KindsEnum } from './constants'
+import { MapPointIconEnum, MapPointKindEnum } from './constants'
 
 export type SelectedUdrZone = {
   Nazov: string
@@ -29,8 +29,8 @@ export type SelectedUdrZone = {
 
 export type SelectedPoint = {
   Navigacia: string // "https://www.google.com/maps/place/Magistr%C3%A1t+hlavn%C3%A9ho+mesta+SR+Bratislavy/@48.1439423,17.1091824,234m/data=!3m3!1e3!4b1!5s0x476c89431d7c7795:0x4caf7acfb0ed99d7!4m5!3m4!1s0x476c89433d1bc761:0x6ad8016ef317f8f0!8m2!3d48.1439414!4d17.1097296"
-  icon: IconsEnum
-  kind: KindsEnum
+  icon: MapPointIconEnum
+  kind: MapPointKindEnum
 }
 
 export type BranchPoint = SelectedPoint & {
@@ -131,7 +131,7 @@ export type NormalizedPoint = {
   name: string
   navigation?: string
   openingHours?: string
-  kind: KindsEnum
+  kind: MapPointKindEnum
   address?: string
   parkingSpotCount?: number
   publicTransportLines?: string
@@ -140,17 +140,17 @@ export type NormalizedPoint = {
 }
 
 type PointTypes = {
-  [KindsEnum.assistant]: SelectedPoint & { kind: KindsEnum.assistant }
-  [KindsEnum.branch]: BranchPoint
-  [KindsEnum.parkomat]: ParkomatPoint
-  [KindsEnum.partner]: PartnerPoint
-  [KindsEnum.pPlusR]: PPlusRPoinit
-  [KindsEnum.garage]: GaragePoint
-  [KindsEnum.parkingLot]: ParkingLotPoint
+  [MapPointKindEnum.assistant]: SelectedPoint & { kind: MapPointKindEnum.assistant }
+  [MapPointKindEnum.branch]: BranchPoint
+  [MapPointKindEnum.parkomat]: ParkomatPoint
+  [MapPointKindEnum.partner]: PartnerPoint
+  [MapPointKindEnum.pPlusR]: PPlusRPoinit
+  [MapPointKindEnum.garage]: GaragePoint
+  [MapPointKindEnum.parkingLot]: ParkingLotPoint
 }
 
 // Type guard function using conditional types
-export function isPointOfType<T extends KindsEnum>(
+export function isPointOfKind<T extends MapPointKindEnum>(
   point: SelectedPoint,
   kind: T,
 ): point is PointTypes[T] {

--- a/modules/map/utils/layer-styles/markers.ts
+++ b/modules/map/utils/layer-styles/markers.ts
@@ -1,4 +1,4 @@
-import { IconsEnum } from '@/modules/map/constants'
+import { MapPointIconEnum } from '@/modules/map/constants'
 
 const iconSize = [
   'interpolate',
@@ -21,13 +21,13 @@ const markersStyles = {
     iconIgnorePlacement: true,
   },
   parkomatCluster: {
-    iconImage: IconsEnum.parkomat,
+    iconImage: MapPointIconEnum.parkomat,
     iconSize,
     iconAllowOverlap: true,
     iconIgnorePlacement: true,
   },
   sellingPointCluster: {
-    iconImage: IconsEnum.partner,
+    iconImage: MapPointIconEnum.partner,
     iconSize,
     iconAllowOverlap: true,
     iconIgnorePlacement: true,

--- a/modules/map/utils/normalizePoint.ts
+++ b/modules/map/utils/normalizePoint.ts
@@ -14,6 +14,7 @@ const resolveName = (point: { Nazov_en: string; Nazov_sk: string }) =>
 export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
   if (isPointOfType(point, KindsEnum.branch)) {
     return {
+      id: point.OBJECTID,
       address: point.Adresa,
       kind: point.kind,
       name: point.Nazov,
@@ -23,6 +24,7 @@ export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
   }
   if (isPointOfType(point, KindsEnum.garage)) {
     return {
+      id: point.OBJECTID,
       address: point.Adresa,
       kind: point.kind,
       name: resolveName(point),
@@ -32,7 +34,7 @@ export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
   }
   if (isPointOfType(point, KindsEnum.pPlusR)) {
     return {
-      address: undefined,
+      id: point.OBJECTID,
       kind: point.kind,
       name: resolveName(point),
       navigation: point.Navigacia,
@@ -45,7 +47,7 @@ export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
   }
   if (isPointOfType(point, KindsEnum.parkingLot)) {
     return {
-      address: undefined,
+      id: point.OBJECTID,
       kind: point.kind,
       name: resolveName(point),
       navigation: point.Navigacia,
@@ -58,15 +60,14 @@ export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
   }
   if (isPointOfType(point, KindsEnum.parkomat)) {
     return {
-      address: undefined,
+      id: point.OBJECTID,
       kind: point.kind,
       name: point.Lokalita,
-      navigation: undefined,
-      openingHours: undefined,
     }
   }
   if (isPointOfType(point, KindsEnum.partner)) {
     return {
+      id: point.OBJECTID,
       address: point.adresa,
       kind: point.kind,
       name: point.Nazov,
@@ -76,11 +77,15 @@ export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
   }
   if (isPointOfType(point, KindsEnum.assistant)) {
     return {
+      id: 0,
+      name: 'N/A',
       kind: point.kind,
     }
   }
 
   return {
+    id: 0,
+    name: 'N/A',
     kind: point.kind,
   }
 }

--- a/modules/map/utils/normalizePoint.ts
+++ b/modules/map/utils/normalizePoint.ts
@@ -1,0 +1,86 @@
+import i18n from '@/i18n.config'
+
+import { KindsEnum } from '../constants'
+import { isPointOfType, NormalizedPoint, SelectedPoint } from '../types'
+
+// eslint-disable-next-line babel/camelcase
+const resolveOpeningHours = (point: { Otvaracie_hodiny_en: string; Otvaracie_hodiny_sk: string }) =>
+  i18n.language === 'en' ? point.Otvaracie_hodiny_en : point.Otvaracie_hodiny_sk
+
+// eslint-disable-next-line babel/camelcase
+const resolveName = (point: { Nazov_en: string; Nazov_sk: string }) =>
+  i18n.language === 'en' ? point.Nazov_en : point.Nazov_sk
+
+export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
+  if (isPointOfType(point, KindsEnum.branch)) {
+    return {
+      address: point.Adresa,
+      kind: point.kind,
+      name: point.Nazov,
+      navigation: point.Navigacia,
+      openingHours: resolveOpeningHours(point),
+    }
+  }
+  if (isPointOfType(point, KindsEnum.garage)) {
+    return {
+      address: point.Adresa,
+      kind: point.kind,
+      name: resolveName(point),
+      navigation: point.Navigacia,
+      openingHours: point.Prevadzkova_doba,
+    }
+  }
+  if (isPointOfType(point, KindsEnum.pPlusR)) {
+    return {
+      address: undefined,
+      kind: point.kind,
+      name: resolveName(point),
+      navigation: point.Navigacia,
+      openingHours: point.Prevadzkova_doba,
+      distanceToCenter: point.Dojazdova_doba,
+      distanceToPublicTransport: point.Vzdialenost,
+      parkingSpotCount: Number.parseInt(point.Pocet_parkovacich_miest, 10),
+      publicTransportLines: point.Verejna_doprava,
+    }
+  }
+  if (isPointOfType(point, KindsEnum.parkingLot)) {
+    return {
+      address: undefined,
+      kind: point.kind,
+      name: resolveName(point),
+      navigation: point.Navigacia,
+      openingHours: point.Prevadzkova_doba,
+      distanceToCenter: point.Dojazdova_doba,
+      distanceToPublicTransport: point.Vzdialenost,
+      parkingSpotCount: Number.parseInt(point.Pocet_parkovacich_miest, 10),
+      publicTransportLines: point.Verejna_doprava,
+    }
+  }
+  if (isPointOfType(point, KindsEnum.parkomat)) {
+    return {
+      address: undefined,
+      kind: point.kind,
+      name: point.Lokalita,
+      navigation: undefined,
+      openingHours: undefined,
+    }
+  }
+  if (isPointOfType(point, KindsEnum.partner)) {
+    return {
+      address: point.adresa,
+      kind: point.kind,
+      name: point.Nazov,
+      navigation: point.Navigacia,
+      openingHours: resolveOpeningHours(point),
+    }
+  }
+  if (isPointOfType(point, KindsEnum.assistant)) {
+    return {
+      kind: point.kind,
+    }
+  }
+
+  return {
+    kind: point.kind,
+  }
+}

--- a/modules/map/utils/normalizePoint.ts
+++ b/modules/map/utils/normalizePoint.ts
@@ -1,7 +1,7 @@
 import i18n from '@/i18n.config'
 
-import { KindsEnum } from '../constants'
-import { isPointOfType, NormalizedPoint, SelectedPoint } from '../types'
+import { MapPointKindEnum } from '../constants'
+import { isPointOfKind, NormalizedPoint, SelectedPoint } from '../types'
 
 // eslint-disable-next-line babel/camelcase
 const resolveOpeningHours = (point: { Otvaracie_hodiny_en: string; Otvaracie_hodiny_sk: string }) =>
@@ -12,7 +12,7 @@ const resolveName = (point: { Nazov_en: string; Nazov_sk: string }) =>
   i18n.language === 'en' ? point.Nazov_en : point.Nazov_sk
 
 export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
-  if (isPointOfType(point, KindsEnum.branch)) {
+  if (isPointOfKind(point, MapPointKindEnum.branch)) {
     return {
       id: point.OBJECTID,
       address: point.Adresa,
@@ -22,7 +22,7 @@ export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
       openingHours: resolveOpeningHours(point),
     }
   }
-  if (isPointOfType(point, KindsEnum.garage)) {
+  if (isPointOfKind(point, MapPointKindEnum.garage)) {
     return {
       id: point.OBJECTID,
       address: point.Adresa,
@@ -32,7 +32,7 @@ export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
       openingHours: point.Prevadzkova_doba,
     }
   }
-  if (isPointOfType(point, KindsEnum.pPlusR)) {
+  if (isPointOfKind(point, MapPointKindEnum.pPlusR)) {
     return {
       id: point.OBJECTID,
       kind: point.kind,
@@ -45,7 +45,7 @@ export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
       publicTransportLines: point.Verejna_doprava,
     }
   }
-  if (isPointOfType(point, KindsEnum.parkingLot)) {
+  if (isPointOfKind(point, MapPointKindEnum.parkingLot)) {
     return {
       id: point.OBJECTID,
       kind: point.kind,
@@ -58,14 +58,14 @@ export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
       publicTransportLines: point.Verejna_doprava,
     }
   }
-  if (isPointOfType(point, KindsEnum.parkomat)) {
+  if (isPointOfKind(point, MapPointKindEnum.parkomat)) {
     return {
       id: point.OBJECTID,
       kind: point.kind,
       name: point.Lokalita,
     }
   }
-  if (isPointOfType(point, KindsEnum.partner)) {
+  if (isPointOfKind(point, MapPointKindEnum.partner)) {
     return {
       id: point.OBJECTID,
       address: point.adresa,
@@ -75,7 +75,7 @@ export const normalizePoint = (point: SelectedPoint): NormalizedPoint => {
       openingHours: resolveOpeningHours(point),
     }
   }
-  if (isPointOfType(point, KindsEnum.assistant)) {
+  if (isPointOfKind(point, MapPointKindEnum.assistant)) {
     return {
       id: 0,
       name: 'N/A',

--- a/modules/map/utils/processData.ts
+++ b/modules/map/utils/processData.ts
@@ -5,7 +5,7 @@ import booleanIntersects from '@turf/boolean-intersects'
 import { Point, Polygon } from '@turf/helpers'
 import intersect from '@turf/intersect'
 import { Feature, FeatureCollection, GeoJsonProperties, Geometry } from 'geojson'
-import { IconsEnum } from '../constants'
+import { MapPointIconEnum } from '../constants'
 
 const zoneMapping = {
   SM1: 'SM1',
@@ -217,7 +217,7 @@ export const processData = ({
           })
           .filter((f) => f.properties?.web === 'ano'),
       ],
-    } as FeatureCollection<Point, GeoJsonProperties | { icon: IconsEnum }>,
+    } as FeatureCollection<Point, GeoJsonProperties | { icon: MapPointIconEnum }>,
     zonesData as FeatureCollection<Polygon, GeoJsonProperties>,
   )
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
+    "local-android": "expo start --android --localhost",
     "ios": "expo start --ios",
     "web": "expo start --web",
     "ts:check": "tsc",

--- a/translations/en.json
+++ b/translations/en.json
@@ -109,10 +109,16 @@
     }
   },
   "MapScreen": {
-    "BottomSheet": {
+    "ZoneBottomSheet": {
       "title": "Where are you parking?",
       "showDetails": "Show details",
-      "noZoneSelected": "No parking zones found. Use search or place the pin to a parking zone nearby."
+      "noZoneSelected": "No parking zones found. Use search or place the pin to a parking zone nearby.",
+    }, "PointBottomSheet": {
+      "title": "Point detail",
+      "address": "Address",
+      "id": "ID",
+      "getDirections": "Get directions",
+      "openingHours": "Opening hours"
     }
   }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -113,12 +113,28 @@
       "title": "Where are you parking?",
       "showDetails": "Show details",
       "noZoneSelected": "No parking zones found. Use search or place the pin to a parking zone nearby."
-    }, "PointBottomSheet": {
+    },
+    "PointBottomSheet": {
       "title": "Point detail",
-      "address": "Address",
-      "id": "ID",
       "getDirections": "Get directions",
-      "openingHours": "Opening hours"
+      "fields": {
+        "address": "Address",
+        "id": "ID",
+        "openingHours": "Opening hours",
+        "parkingSpotCount": "Parking spot count",
+        "publicTransportLines": "Public transport lines",
+        "distanceToCenter": "Distance to the city center",
+        "distanceToPublicTransport": "Distance to public transport"
+      },
+      "kinds": {
+        "assistants": "Assistant",
+        "branches": "Branch",
+        "parkomats": "Parkomat",
+        "partners": "Partner",
+        "p-plus-r": "P + R",
+        "garages": "Garage",
+        "parking-lots": "Parking lot"
+      }
     }
   }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -112,7 +112,7 @@
     "ZoneBottomSheet": {
       "title": "Where are you parking?",
       "showDetails": "Show details",
-      "noZoneSelected": "No parking zones found. Use search or place the pin to a parking zone nearby.",
+      "noZoneSelected": "No parking zones found. Use search or place the pin to a parking zone nearby."
     }, "PointBottomSheet": {
       "title": "Point detail",
       "address": "Address",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -83,10 +83,32 @@
     "validUntil": "Platný do"
   },
   "MapScreen": {
-    "BottomSheet": {
+    "ZoneBottomSheet": {
       "title": "Kde parkujete?",
       "showDetails": "Ukázať detail",
       "noZoneSelected": "Nenašli sa žiadne parkovacie zóny. Použite vyhľadávanie alebo premiestnite pin na niektorú zo zón v blízkosti."
+    },
+    "PointBottomSheet": {
+      "title": "Detail bodu",
+      "getDirections": "Navigácia",
+      "fields": {
+        "address": "Adresa",
+        "id": "ID",
+        "openingHours": "Otváracie hodiny",
+        "parkingSpotCount": "Počet parkovacích miest",
+        "publicTransportLines": "Linky MHD",
+        "distanceToCenter": "Vzdialenosť do centra",
+        "distanceToPublicTransport": "Vzdialenosť k zastávke MHD"
+      },
+      "kinds": {
+        "assistants": "Asistent",
+        "branches": "Prevádzka",
+        "parkomats": "Parkomat",
+        "partners": "Partnerská prevádzka",
+        "p-plus-r": "P + R",
+        "garages": "Garáž",
+        "parking-lots": "Parkovisko"
+      }
     }
   }
 }


### PR DESCRIPTION
- added point detail BottomSheet
- points for a discussion:
  - **how to handle point clustering, should all types of points be clustered together?** This is the way it is for the map on the PaaS website, or should the points be clustered separately? This would show the correct icon for clusters, it is the current behavior
  - the data format for the point types is almost completely different for all of them, the variable names are in Slovak (why? 😧) some of them do not have an address, some of them do not have a navigation URL, some do not have a name, **what data do we want to show, since the design handles only one from the 7 cases?**
  - also, the format of the data is very weird to say the least, e.g. `"N/A"` values instead of a `null`, opening hours are not formatted but are a single line of text, etc.
  - **the animation**, right now is done using `LayoutAnimation`, this is the easiest way and looks pretty good, more precise animation requires animating it manually using `Animated` (from `react-native` or `reanimated`)