### PR TITLE
Feat/#136 duration in second

### DIFF
--- a/app/purchase/index.tsx
+++ b/app/purchase/index.tsx
@@ -58,7 +58,7 @@ const PurchaseScreen = () => {
   // Run query only if all required attributes are present
   const isQueryEnabled = !!udr && !!licencePlate && !!duration
 
-  const parkingEnd = new Date(Date.now() + duration * 60_000).toISOString()
+  const parkingEnd = new Date(Date.now() + duration * 1000).toISOString()
   const body: GetTicketPriceRequestDto = {
     npkId: npk?.identificator || undefined,
     ticket: {

--- a/components/controls/date-time/TimeSelector.tsx
+++ b/components/controls/date-time/TimeSelector.tsx
@@ -100,8 +100,10 @@ const TimeSelector = ({ value, onValueChange }: Props) => {
           onPress={addTime}
         />
       </FlexRow>
+
+      {/* Hardcoded h-[48px] prevents chips to shrink */}
       <View className="g-1">
-        <View className="flex-row g-1">
+        <View className="h-[48px] flex-row g-1">
           {chips.slice(0, 4).map((chip) => {
             return (
               <PressableStyled
@@ -114,7 +116,7 @@ const TimeSelector = ({ value, onValueChange }: Props) => {
             )
           })}
         </View>
-        <View className="flex-row g-1">
+        <View className="h-[48px] flex-row g-1">
           {chips.slice(4).map((chip) => {
             return (
               <PressableStyled

--- a/components/controls/date-time/TimeSelector.tsx
+++ b/components/controls/date-time/TimeSelector.tsx
@@ -31,31 +31,37 @@ const TimeSelector = ({ value, onValueChange }: Props) => {
   const [datePickerOpen, setDatePickerOpen] = useState(false)
 
   const validUntil = useMemo(
-    () => formatDateTime(new Date(Date.now() + value * 60_000), locale),
+    () => formatDateTime(new Date(Date.now() + value * 1000), locale),
     [locale, value],
   )
 
+  /**
+   * Add 15 minutes
+   */
   const addTime = () => {
-    onValueChange(value + 15)
+    onValueChange(value + 15 * 60)
   }
 
+  /**
+   * Subtract 15 minutes
+   */
   const subtractTime = () => {
-    onValueChange(Math.max(0, value - 15))
+    onValueChange(Math.max(0, value - 15 * 60))
   }
 
-  const setTime = (minutes: number) => {
-    onValueChange(minutes)
+  const setTime = (value: number) => {
+    onValueChange(value)
   }
 
   const chips = useMemo(
     () => [
-      { value: 15, label: '15 min' },
-      { value: 30, label: '30 min' },
-      { value: 45, label: '45 min' },
-      { value: 60, label: '1 h' },
-      { value: 120, label: '2 h' },
-      { value: 240, label: '4 h' },
-      { value: 480, label: '8 h' },
+      { value: 15 * 60, label: '15 min' },
+      { value: 30 * 60, label: '30 min' },
+      { value: 45 * 60, label: '45 min' },
+      { value: 60 * 60, label: '1 h' },
+      { value: 2 * 60 * 60, label: '2 h' },
+      { value: 4 * 60 * 60, label: '4 h' },
+      { value: 8 * 60 * 60, label: '8 h' },
     ],
     [],
   )
@@ -113,7 +119,7 @@ const TimeSelector = ({ value, onValueChange }: Props) => {
             return (
               <PressableStyled
                 key={chip.value}
-                onPress={() => setTime(Number(chip.value))}
+                onPress={() => setTime(chip.value)}
                 className="flex-1"
               >
                 <Chip label={chip.label} isActive={chip.value === value} />

--- a/components/shared/Chip.tsx
+++ b/components/shared/Chip.tsx
@@ -14,7 +14,7 @@ const Chip = ({ label, isActive, chipClassName }: Props) => {
   return (
     <View
       className={clsx(
-        'flex-1 items-center justify-center rounded border p-3',
+        'h-[48px] flex-1 items-center justify-center rounded border',
         isActive ? 'border-dark bg-dark' : 'border-divider bg-white',
         chipClassName,
       )}

--- a/components/tickets/PurchaseBottomSheet.tsx
+++ b/components/tickets/PurchaseBottomSheet.tsx
@@ -8,6 +8,7 @@ import Button from '@/components/shared/Button'
 import Divider from '@/components/shared/Divider'
 import FlexRow from '@/components/shared/FlexRow'
 import Typography from '@/components/shared/Typography'
+import { getDurationFromPriceData } from '@/components/tickets/getDurationFromPriceData'
 import { useTranslation } from '@/hooks/useTranslation'
 import { GetTicketPriceResponseDto } from '@/modules/backend/openapi-generated'
 import { formatDuration } from '@/utils/formatDuration'
@@ -21,6 +22,8 @@ type Props = {
 
 const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(({ priceData, isLoading }, ref) => {
   const t = useTranslation('PurchaseScreen')
+
+  const durationFromPriceDate = getDurationFromPriceData(priceData)
 
   const insets = useSafeAreaInsets()
   // TODO tmp for now - fixed height from figma
@@ -45,18 +48,6 @@ const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(({ priceData, isLoadi
   //   [t],
   // )
 
-  // TODO use seconds
-  const getDurationFromPriceData = () => {
-    if (!priceData) {
-      return 0
-    }
-
-    const ticketStartDate = new Date(priceData.ticketStart)
-    const ticketEndDate = new Date(priceData.ticketEnd)
-
-    return (ticketEndDate.getTime() - ticketStartDate.getTime()) / 1000 / 60
-  }
-
   return (
     <>
       <BottomSheet
@@ -70,7 +61,7 @@ const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(({ priceData, isLoadi
           <BottomSheetContent cn="g-3" hideSpacer>
             <FlexRow>
               <Typography variant="default">
-                Parkovanie {formatDuration(getDurationFromPriceData())}
+                Parkovanie {formatDuration(durationFromPriceDate ?? 0)}
               </Typography>
               <Typography variant="default-bold">
                 {formatPrice(priceData.priceWithoutDiscount)}
@@ -87,8 +78,8 @@ const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(({ priceData, isLoadi
               </FlexRow>
             )}
 
-            {/* Check if it is present (null/undefined, but show if it is 0) */}
-            {priceData.creditBPKUsed == null ? null : (
+            {/* Show creditBPKUsed nly if it is defined and "non-zero" */}
+            {!priceData.creditBPKUsed || priceData.creditBPKUsed === 'PT0S' ? null : (
               <FlexRow>
                 <Typography variant="default">Stiahnuté z bonusovej karty</Typography>
                 <Typography variant="default-bold">

--- a/components/tickets/getDurationFromPriceData.ts
+++ b/components/tickets/getDurationFromPriceData.ts
@@ -1,0 +1,15 @@
+import { GetTicketPriceResponseDto } from '@/modules/backend/openapi-generated'
+
+export const getDurationFromPriceData = (priceData: GetTicketPriceResponseDto | undefined) => {
+  if (!priceData) {
+    return null
+  }
+
+  const ticketStartDate = new Date(priceData.ticketStart)
+  const ticketEndDate = new Date(priceData.ticketEnd)
+
+  // Difference in milliseconds
+  const diff = ticketEndDate.getTime() - ticketStartDate.getTime()
+
+  return diff / 1000
+}

--- a/utils/formatDuration.ts
+++ b/utils/formatDuration.ts
@@ -1,9 +1,13 @@
-export const formatDuration = (minutes: number) => {
-  const hours = Math.floor(minutes / 60)
-  const minutesLeft = minutes % 60
+export const formatDuration = (seconds: number) => {
+  const roundedInMinutes = Math.round(seconds / 60)
+
+  // compute whole hours
+  const hours = Math.floor(roundedInMinutes / 60)
+  // compute residuum in minutes
+  const minutesLeft = roundedInMinutes % 60
 
   const hoursPart = hours > 0 ? `${hours} h` : ''
   const minutesPart = hours > 0 && minutesLeft === 0 ? '' : `${minutesLeft} min`
 
-  return `${hoursPart}${hoursPart.length > 0 ? ' ' : ''}${minutesPart}`
+  return `${hoursPart} ${minutesPart}`.trim()
 }


### PR DESCRIPTION
- change `duration` to be stored in seconds instead of minutes
- fix collapsing `Chips` in `TimeSelector` by setting fixed height
- remove `p-3` from Chip styles to give more space to text on small screens