### PR TITLE
feat/#144: implement verification result screens

### DIFF
--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -67,7 +67,15 @@ const Page = () => {
       <ScreenContent>
         <Typography variant="h1">{t('enterPhoneNumber')}</Typography>
 
-        <TextInput keyboardType="phone-pad" value={phone} onChangeText={setPhone} />
+        {/* Note that `onSubmitEditing` on iOS isn't called when using keyboardType="phone-pad". */}
+        {/* https://reactnative.dev/docs/textinput#onsubmitediting  */}
+        <TextInput
+          value={phone}
+          onChangeText={setPhone}
+          keyboardType="phone-pad"
+          autoComplete="tel"
+          onSubmitEditing={attemptSignInOrSignUp}
+        />
 
         <Typography>{t('consent')}</Typography>
 

--- a/app/confirm-signin.tsx
+++ b/app/confirm-signin.tsx
@@ -43,7 +43,14 @@ const Page = () => {
       <ScreenContent>
         <Typography variant="h1">{t('EnterVerificationCode.enterVerificationCode')}</Typography>
 
-        <TextInput keyboardType="number-pad" value={code} onChangeText={setCode} />
+        <TextInput
+          value={code}
+          onChangeText={setCode}
+          keyboardType="number-pad"
+          autoComplete="one-time-code"
+          textAlign="center"
+          onSubmitEditing={confirmSignIn}
+        />
 
         <Typography>{t('EnterVerificationCode.instructions')}</Typography>
 

--- a/app/confirm-signup.tsx
+++ b/app/confirm-signup.tsx
@@ -43,7 +43,14 @@ const Page = () => {
       <ScreenContent>
         <Typography variant="h1">{t('EnterVerificationCode.enterVerificationCode')}</Typography>
 
-        <TextInput keyboardType="number-pad" value={code} onChangeText={setCode} />
+        <TextInput
+          value={code}
+          onChangeText={setCode}
+          keyboardType="number-pad"
+          autoComplete="one-time-code"
+          textAlign="center"
+          onSubmitEditing={confirmSignUp}
+        />
 
         <Typography>{t('EnterVerificationCode.instructions')}</Typography>
 

--- a/app/parking-cards/[email].tsx
+++ b/app/parking-cards/[email].tsx
@@ -8,6 +8,7 @@ import { SceneMap, TabView } from 'react-native-tab-view'
 import TabBar from '@/components/navigation/TabBar'
 import EmailsBottomSheet from '@/components/parking-cards/EmailsBottomSheet'
 import ParkingCard from '@/components/parking-cards/ParkingCard'
+import EmptyStateScreen from '@/components/screen-layout/EmptyStateScreen'
 import ScreenContent from '@/components/screen-layout/ScreenContent'
 import ScreenView from '@/components/screen-layout/ScreenView'
 import IconButton from '@/components/shared/IconButton'
@@ -21,6 +22,7 @@ export type ParkingCardsLocalSearchParams = {
 }
 
 const Active = () => {
+  const t = useTranslation('ParkingCards')
   const { email } = useLocalSearchParams<ParkingCardsLocalSearchParams>()
 
   const { data, isPending, isError, error } = useQuery(parkingCardsOptions({ email }))
@@ -34,6 +36,10 @@ const Active = () => {
   }
 
   const cards = data.parkingCards
+
+  if (cards.length === 0) {
+    return <EmptyStateScreen title={t('noActiveCardsTitle')} text={t('noActiveCardsText')} />
+  }
 
   // TODO pagination
   return (

--- a/app/parking-cards/index.tsx
+++ b/app/parking-cards/index.tsx
@@ -3,8 +3,10 @@ import { Link, Stack } from 'expo-router'
 import { FlatList } from 'react-native'
 
 import ListRow from '@/components/list-rows/ListRow'
+import EmptyStateScreen from '@/components/screen-layout/EmptyStateScreen'
 import ScreenContent from '@/components/screen-layout/ScreenContent'
 import ScreenView from '@/components/screen-layout/ScreenView'
+import Button from '@/components/shared/Button'
 import Divider from '@/components/shared/Divider'
 import IconButton from '@/components/shared/IconButton'
 import PressableStyled from '@/components/shared/PressableStyled'
@@ -26,15 +28,31 @@ const Page = () => {
     return <Typography>Error: {error.message}</Typography>
   }
 
+  if (data.verifiedEmails.length === 0) {
+    return (
+      <EmptyStateScreen
+        title={t('noEmailsTitle')}
+        text={t('noEmailsText')}
+        button={
+          <Link asChild href="/parking-cards/verification">
+            <Button>{t('addParkingCards')}</Button>
+          </Link>
+        }
+        buttonPosition="insideContent"
+      />
+    )
+  }
+
   return (
     <ScreenView title={t('paasEmailsTitle')}>
       <Stack.Screen
         options={{
-          headerRight: () => (
-            <Link asChild href="/parking-cards/verification">
-              <IconButton name="add" accessibilityLabel={t('addParkingCards')} />
-            </Link>
-          ),
+          headerRight: () =>
+            data.verifiedEmails.length > 0 ? (
+              <Link asChild href="/parking-cards/verification">
+                <IconButton name="add" accessibilityLabel={t('addParkingCards')} />
+              </Link>
+            ) : null,
         }}
       />
 

--- a/app/parking-cards/index.tsx
+++ b/app/parking-cards/index.tsx
@@ -31,7 +31,7 @@ const Page = () => {
       <Stack.Screen
         options={{
           headerRight: () => (
-            <Link asChild href="/parking-cards/enter-paas-account">
+            <Link asChild href="/parking-cards/verification">
               <IconButton name="add" accessibilityLabel={t('addParkingCards')} />
             </Link>
           ),

--- a/app/parking-cards/verification/index.tsx
+++ b/app/parking-cards/verification/index.tsx
@@ -27,13 +27,22 @@ const Page = () => {
   // TODO add email validation
   const isValid = email.includes('@')
 
+  // TODO deduplicate this mutation (it's also used in link-expired.tsx)
   const mutation = useMutation({
     mutationFn: (bodyInner: VerifyEmailsDto) =>
       clientApi.verifiedEmailsControllerSendEmailVerificationEmails(bodyInner),
-    onError: (error) => {
-      // TODO handle error, show snackbar?
-      // Handled in mutation to be sure that snackbar is shown on error
-      console.log('error', error)
+    onSuccess: (res) => {
+      const tmpVerificationToken = res.data[0].token
+      const tmpVerificationKey = res.data[0].key
+
+      router.push({
+        pathname: '/parking-cards/verification/verification-sent',
+        params: {
+          emailToVerify: email,
+          tmpVerificationKey,
+          tmpVerificationToken,
+        },
+      })
     },
   })
 
@@ -42,17 +51,7 @@ const Page = () => {
       emails: [email],
     }
 
-    mutation.mutate(body, {
-      onSuccess: (res) => {
-        const tmpVerificationToken = res.data[0].token
-        const verificationKey = res.data[0].key
-        console.log('success', tmpVerificationToken, verificationKey)
-        router.push({
-          pathname: '/parking-cards/verification-sent',
-          params: { emailToVerify: email, verificationKey, tmpVerificationToken },
-        })
-      },
-    })
+    mutation.mutate(body)
   }
 
   return (

--- a/app/parking-cards/verification/index.tsx
+++ b/app/parking-cards/verification/index.tsx
@@ -46,7 +46,7 @@ const Page = () => {
     },
   })
 
-  const handlePress = () => {
+  const handleSendVerificationEmail = () => {
     const body: VerifyEmailsDto = {
       emails: [email],
     }
@@ -59,10 +59,13 @@ const Page = () => {
       <ScreenContent>
         <Field label={t('emailField')}>
           <TextInput
-            keyboardType="email-address"
-            autoCapitalize="none"
             value={email}
             onChangeText={setEmail}
+            keyboardType="email-address"
+            autoCapitalize="none"
+            autoComplete="email"
+            autoCorrect={false}
+            onSubmitEditing={handleSendVerificationEmail}
           />
         </Field>
 
@@ -70,7 +73,11 @@ const Page = () => {
           <Typography>{t('instructions')}</Typography>
         </Panel>
 
-        <ContinueButton onPress={handlePress} disabled={!isValid} loading={mutation.isPending} />
+        <ContinueButton
+          onPress={handleSendVerificationEmail}
+          disabled={!isValid}
+          loading={mutation.isPending}
+        />
       </ScreenContent>
     </ScreenView>
   )

--- a/app/parking-cards/verification/verification-result.tsx
+++ b/app/parking-cards/verification/verification-result.tsx
@@ -1,0 +1,90 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Link, router, Stack, useLocalSearchParams } from 'expo-router'
+import React from 'react'
+
+import ContinueButton from '@/components/navigation/ContinueButton'
+import ContentWithAvatar from '@/components/screen-layout/ContentWithAvatar'
+import ScreenViewCentered from '@/components/screen-layout/ScreenViewCentered'
+import { useTranslation } from '@/hooks/useTranslation'
+import { clientApi } from '@/modules/backend/client-api'
+import { verifiedEmailsOptions } from '@/modules/backend/constants/queryOptions'
+import { VerifyEmailsDto } from '@/modules/backend/openapi-generated'
+
+/**
+ * This page handles redirects from BE to show email verification result.
+ *
+ * Do not change the path unless it's changed in BE as well!
+ *
+ * Figma: https://www.figma.com/file/3TppNabuUdnCChkHG9Vft7/paas-mpa?node-id=1300%3A11943&mode=dev
+ */
+
+type VerificationResultSearchParams = {
+  email: string
+  status: 'verified' | 'verified-no-cards' | 'link-expired'
+}
+
+const VerificationResultPage = () => {
+  const t = useTranslation('VerificationResult')
+  const queryClient = useQueryClient()
+  const { email, status } = useLocalSearchParams<VerificationResultSearchParams>()
+
+  queryClient.refetchQueries({ queryKey: verifiedEmailsOptions().queryKey, type: 'active' })
+
+  // TODO deduplicate this mutation (it's also used in ./index.tsx)
+  const mutation = useMutation({
+    mutationFn: (bodyInner: VerifyEmailsDto) =>
+      clientApi.verifiedEmailsControllerSendEmailVerificationEmails(bodyInner),
+    onSuccess: (res) => {
+      const tmpVerificationToken = res.data[0].token
+      const tmpVerificationKey = res.data[0].key
+
+      router.push({
+        pathname: '/parking-cards/verification/verification-sent',
+        params: {
+          emailToVerify: email,
+          tmpVerificationKey,
+          tmpVerificationToken,
+        },
+      })
+    },
+  })
+
+  const handleResendVerification = () => {
+    const body: VerifyEmailsDto = {
+      emails: [email ?? ''],
+    }
+
+    mutation.mutate(body)
+  }
+
+  return (
+    <ScreenViewCentered
+      actionButton={
+        status === 'link-expired' ? (
+          <ContinueButton onPress={handleResendVerification}>
+            {t(`${status}.actionButtonLabel`)}
+          </ContinueButton>
+        ) : (
+          <Link asChild replace href={{ pathname: '/parking-cards' }}>
+            <ContinueButton>{t(`${status}.actionButtonLabel`)}</ContinueButton>
+          </Link>
+        )
+      }
+    >
+      <Stack.Screen options={{ headerShown: false }} />
+
+      {email && status ? (
+        <ContentWithAvatar
+          variant={status.startsWith('verified') ? 'success' : 'error'}
+          title={t(`${status}.title`)}
+          text={t(`${status}.text`, { email })}
+        />
+      ) : (
+        // TODO
+        <ContentWithAvatar variant="error" title="Unexpected error" />
+      )}
+    </ScreenViewCentered>
+  )
+}
+
+export default VerificationResultPage

--- a/app/parking-cards/verification/verification-sent.tsx
+++ b/app/parking-cards/verification/verification-sent.tsx
@@ -12,29 +12,28 @@ import { clientApi } from '@/modules/backend/client-api'
 
 // TODO remove - this button simulates email verification
 const TmpVerifyButton = () => {
-  const { tmpVerificationToken, verificationKey } = useLocalSearchParams<{
+  const { tmpVerificationToken, tmpVerificationKey, emailToVerify } = useLocalSearchParams<{
+    emailToVerify: string
     tmpVerificationToken: string
-    verificationKey: string
+    tmpVerificationKey: string
   }>()
 
   const mutation = useMutation({
     mutationFn: () =>
       clientApi.verifiedEmailsControllerVerifyEmail(
         tmpVerificationToken ?? '',
-        verificationKey ?? '',
+        tmpVerificationKey ?? '',
       ),
-    onError: (error) => {
-      // TODO handle error, show snackbar?
-      // Handled in mutation to be sure that snackbar is shown on error
-      console.log('error', error)
-    },
   })
 
   const handlePressVerify = () => {
     mutation.mutate(undefined, {
       onSuccess: (res) => {
         console.log('success', res.status)
-        router.push('/parking-cards')
+        router.push({
+          pathname: '/parking-cards/verification/verification-result',
+          params: { email: emailToVerify, status: 'verified' },
+        })
       },
     })
   }

--- a/components/inputs/Autocomplete.tsx
+++ b/components/inputs/Autocomplete.tsx
@@ -156,6 +156,7 @@ const AutocompleteInner = <O,>(
         autoFocus={autoFocus}
         selection={textSelection}
         onSelectionChange={handleSelectionChange}
+        returnKeyType="search"
       />
       <View>
         {optionsPortalName ? (

--- a/components/parking-cards/EmailsBottomSheet.tsx
+++ b/components/parking-cards/EmailsBottomSheet.tsx
@@ -1,5 +1,5 @@
 import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps } from '@gorhom/bottom-sheet'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { router, useLocalSearchParams } from 'expo-router'
 import React, { forwardRef, useCallback } from 'react'
 
@@ -9,20 +9,24 @@ import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomShe
 import PressableStyled from '@/components/shared/PressableStyled'
 import { useTranslation } from '@/hooks/useTranslation'
 import { clientApi } from '@/modules/backend/client-api'
+import { verifiedEmailsOptions } from '@/modules/backend/constants/queryOptions'
 
 // TODO FIXME bottom sheet is empty on Android
 const EmailsBottomSheet = forwardRef<BottomSheet>((props, ref) => {
   const t = useTranslation('ParkingCards')
+  const queryClient = useQueryClient()
   const { emailId } = useLocalSearchParams<ParkingCardsLocalSearchParams>()
 
   const parsedEmailId = emailId ? Number.parseInt(emailId, 10) : null
 
   const mutation = useMutation({
     mutationFn: (id: number) => clientApi.verifiedEmailsControllerDeleteVerifiedEmail(id),
-    onError: (error) => {
-      // TODO handle error, show snackbar?
-      // Handled in mutation to be sure that snackbar is shown on error
-      console.log('error deleting email', error)
+    onSuccess: async () => {
+      // Refetch verified emails
+      await queryClient.refetchQueries({
+        queryKey: verifiedEmailsOptions().queryKey,
+        type: 'active',
+      })
     },
   })
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -145,11 +145,15 @@
     "openEmailActions": "Manage e-mail address",
     "emailActions": {
       "removeEmail": "Remove e-mail address"
-    }
+    },
+    "noEmailsTitle": "No parking cards",
+    "noEmailsText": "To add your cards to the app, please connect with your PAAS account.",
+    "noActiveCardsTitle": "No active parking cards",
+    "noActiveCardsText": "All parking cards expired. Once you’ll buy new parking card, it will show here."
   },
   "VerificationResult": {
     "verified": {
-      "title": "Parking card added",
+      "title": "Parking cards added",
       "text": "Your parking cards e-mail {{email}} has been added. You can see your cards in the Parking cards section.",
       "actionButtonLabel": "Continue"
     },

--- a/translations/en.json
+++ b/translations/en.json
@@ -147,6 +147,23 @@
       "removeEmail": "Remove e-mail address"
     }
   },
+  "VerificationResult": {
+    "verified": {
+      "title": "Parking card added",
+      "text": "Your parking cards e-mail {{email}} has been added. You can see your cards in the Parking cards section.",
+      "actionButtonLabel": "Continue"
+    },
+    "verified-no-cards": {
+      "title": "No parking cards",
+      "text": "We apologize, but no parking cards were found for the e-mail address {{email}}.\n\nPlease contact paas.sk support.",
+      "actionButtonLabel": "Continue"
+    },
+    "link-expired": {
+      "title": "Link expired",
+      "text": "We are sorry, but link to verify your e-mail has expired. Resend e-mail to {{email}} and verify it again.\n\nClick on Verify button in the e-mail to approve verification and we will then add parking cards directly to the app.",
+      "actionButtonLabel": "Resend & continue"
+    }
+  },
   "TimeSelector": {
     "addTimeButton": "Add 15 minutes",
     "subtractTimeButton": "Subtract 15 minutes",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -147,6 +147,23 @@
       "removeEmail": "Odstrániť e-mail"
     }
   },
+  "VerificationResult": {
+    "verified": {
+      "title": "Parkovacie karty pridané",
+      "text": "Vaše parkovacie karty pre e-mailovú adresu {{email}} boli pridané. Zoznam všetkých kariet nájdete v časti Parkovacie karty.",
+      "actionButtonLabel": "Pokračovať"
+    },
+    "verified-no-cards": {
+      "title": "Žiadne parkovacie karty",
+      "text": "Pre e-mailovú adresu {{email}} neboli nájdené žiadne parkovacie karty.\n\nProsím, skúste kontaktovať podporu paas.sk.",
+      "actionButtonLabel": "Pokračovať"
+    },
+    "link-expired": {
+      "title": "Platnosť vypršala",
+      "text": "Je nám ľúto, ale platnosť odkazu na overenie vašej e-mailovej adresy vypršala. Zopakujte odoslanie e-mailu na adresu {{email}}.\n\nKliknutím na tlačidlo Overiť pridáme vaše parkovacie karty priamo do aplikácie.",
+      "actionButtonLabel": "Opätovne odoslať a pokračovať"
+    }
+  },
   "ZoneBottomSheet": {
     "title": "Kde parkujete?",
     "showDetails": "Detail úseku",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -145,7 +145,11 @@
     "openEmailActions": "Spravovať e-mail",
     "emailActions": {
       "removeEmail": "Odstrániť e-mail"
-    }
+    },
+    "noEmailsTitle": "Žiadne parkovacie karty",
+    "noEmailsText": "Ak chcete pridať svoje karty do aplikácie, overte sa e-mailovou adresou, ktorú ste zadali v PAAS.",
+    "noActiveCardsTitle": "Žiadne aktívne karty",
+    "noActiveCardsText": "Platnosť všetkých parkovacích kariet vypršala. Po zakúpení novej parkovacej karty ju nájdete v tejto sekcii."
   },
   "VerificationResult": {
     "verified": {


### PR DESCRIPTION
- implement `/parking-cards/verification/verification-result` page, that handle redirects from BE to show email verification status
- refetch verified emails when added or deleted
- reorganize verification screens
- add some TextInput props to improve UX
- add empty state screens
  - EmptyStateScreen still need some updates (it's not always whole screen, reflect screen title and content title...)

TODO
- deduplicate mutation code for sending verification email