### PR TITLE
quickfix registration process by two confirm screens

### DIFF
--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -1,5 +1,3 @@
-import { Auth } from 'aws-amplify'
-import { router } from 'expo-router'
 import { useState } from 'react'
 
 import TextInput from '@/components/inputs/TextInput'
@@ -7,60 +5,15 @@ import ContinueButton from '@/components/navigation/ContinueButton'
 import ScreenContent from '@/components/screen-layout/ScreenContent'
 import ScreenView from '@/components/screen-layout/ScreenView'
 import Typography from '@/components/shared/Typography'
+import { useSignInOrSignUp } from '@/hooks/useSignInOrSignUp'
 import { useTranslation } from '@/hooks/useTranslation'
-import { STATIC_TEMP_PASS } from '@/modules/cognito/amplify'
-import { useGlobalStoreContext } from '@/state/GlobalStoreProvider/useGlobalStoreContext'
-import { GENERIC_ERROR_MESSAGE, isError, isErrorWithCode } from '@/utils/errors'
 
 const Page = () => {
   const t = useTranslation('EnterPhoneNumber')
 
   const [phone, setPhone] = useState('+421')
 
-  const { setSignInResult, setSignUpPhone } = useGlobalStoreContext()
-
-  const attemptSignInOrSignUp = async () => {
-    try {
-      try {
-        const loginResultInner = await Auth.signIn(phone, STATIC_TEMP_PASS)
-        if (loginResultInner) {
-          setSignInResult(loginResultInner)
-          router.push('/confirm-signin')
-        }
-      } catch (error) {
-        if (
-          isError(error) &&
-          isErrorWithCode(error) &&
-          error.code === 'UserNotConfirmedException'
-        ) {
-          console.log('UserNotConfirmedException')
-          // TODO @mpinter investigate autoSignIn after resendSignUp
-          setSignUpPhone(phone)
-          await Auth.resendSignUp(phone)
-          router.push({ pathname: '/confirm-signup' })
-        } else {
-          // TODO @mpinter only sing up on some errors, not on all, throw the rest
-          console.log('Other errors - TODO chose which to handle and which to throw.')
-
-          setSignUpPhone(phone)
-          await Auth.signUp({
-            username: phone,
-            password: STATIC_TEMP_PASS,
-            autoSignIn: {
-              enabled: true,
-            },
-          })
-          router.push({ pathname: '/confirm-signup' })
-        }
-      }
-    } catch (error) {
-      if (isError(error)) {
-        console.error(`Login Error:`, error)
-      } else {
-        console.error(`${GENERIC_ERROR_MESSAGE} - unexpected object thrown in signUp:`, error)
-      }
-    }
-  }
+  const { attemptSignInOrSignUp } = useSignInOrSignUp()
 
   return (
     <ScreenView>
@@ -74,12 +27,13 @@ const Page = () => {
           onChangeText={setPhone}
           keyboardType="phone-pad"
           autoComplete="tel"
-          onSubmitEditing={attemptSignInOrSignUp}
+          autoFocus
+          onSubmitEditing={() => attemptSignInOrSignUp(phone)}
         />
 
         <Typography>{t('consent')}</Typography>
 
-        <ContinueButton onPress={attemptSignInOrSignUp} />
+        <ContinueButton onPress={() => attemptSignInOrSignUp(phone)} />
       </ScreenContent>
     </ScreenView>
   )

--- a/app/confirm-signin.tsx
+++ b/app/confirm-signin.tsx
@@ -49,6 +49,7 @@ const Page = () => {
           keyboardType="number-pad"
           autoComplete="one-time-code"
           textAlign="center"
+          autoFocus
           onSubmitEditing={confirmSignIn}
         />
 

--- a/app/confirm-signup.tsx
+++ b/app/confirm-signup.tsx
@@ -7,6 +7,7 @@ import ScreenContent from '@/components/screen-layout/ScreenContent'
 import ScreenView from '@/components/screen-layout/ScreenView'
 import Button from '@/components/shared/Button'
 import Typography from '@/components/shared/Typography'
+import { useSignInOrSignUp } from '@/hooks/useSignInOrSignUp'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useGlobalStoreContext } from '@/state/GlobalStoreProvider/useGlobalStoreContext'
 import { GENERIC_ERROR_MESSAGE, isError } from '@/utils/errors'
@@ -16,13 +17,16 @@ const Page = () => {
   const [code, setCode] = useState('')
 
   const { signUpPhone, setSignUpPhone } = useGlobalStoreContext()
+  const { attemptSignInOrSignUp } = useSignInOrSignUp()
 
   const confirmSignUp = async () => {
     try {
       if (signUpPhone) {
         await Auth.confirmSignUp(signUpPhone, code)
+        /* Try to sign in (second sms code will be sent) */
+        await attemptSignInOrSignUp(signUpPhone)
         setSignUpPhone(null)
-        router.push('/')
+        router.push('/confirm-signin')
       } else {
         console.log('Unexpected error, no signUpPhone provided in GlobalStore.')
       }
@@ -49,6 +53,7 @@ const Page = () => {
           keyboardType="number-pad"
           autoComplete="one-time-code"
           textAlign="center"
+          autoFocus
           onSubmitEditing={confirmSignUp}
         />
 

--- a/hooks/useSignInOrSignUp.ts
+++ b/hooks/useSignInOrSignUp.ts
@@ -1,0 +1,55 @@
+import { Auth } from 'aws-amplify'
+import { router } from 'expo-router'
+
+import { STATIC_TEMP_PASS } from '@/modules/cognito/amplify'
+import { useGlobalStoreContext } from '@/state/GlobalStoreProvider/useGlobalStoreContext'
+import { GENERIC_ERROR_MESSAGE, isError, isErrorWithCode } from '@/utils/errors'
+
+export const useSignInOrSignUp = () => {
+  const { setSignInResult, setSignUpPhone } = useGlobalStoreContext()
+
+  const attemptSignInOrSignUp = async (phone: string) => {
+    try {
+      try {
+        const loginResultInner = await Auth.signIn(phone, STATIC_TEMP_PASS)
+        if (loginResultInner) {
+          setSignInResult(loginResultInner)
+          router.push('/confirm-signin')
+        }
+      } catch (error) {
+        if (
+          isError(error) &&
+          isErrorWithCode(error) &&
+          error.code === 'UserNotConfirmedException'
+        ) {
+          console.log('UserNotConfirmedException')
+          // TODO @mpinter investigate autoSignIn after resendSignUp
+          setSignUpPhone(phone)
+          await Auth.resendSignUp(phone)
+          router.push({ pathname: '/confirm-signup' })
+        } else {
+          // TODO @mpinter only sing up on some errors, not on all, throw the rest
+          console.log('Other errors - TODO chose which to handle and which to throw.')
+
+          setSignUpPhone(phone)
+          await Auth.signUp({
+            username: phone,
+            password: STATIC_TEMP_PASS,
+            // autoSignIn: {
+            //   enabled: true,
+            // },
+          })
+          router.push({ pathname: '/confirm-signup' })
+        }
+      }
+    } catch (error) {
+      if (isError(error)) {
+        console.error(`Login Error:`, error)
+      } else {
+        console.error(`${GENERIC_ERROR_MESSAGE} - unexpected object thrown in signUp:`, error)
+      }
+    }
+  }
+
+  return { attemptSignInOrSignUp }
+}


### PR DESCRIPTION
- MFA forces us to enter second code after first login (first code is registration verification, second code is authentication verification)
- this PR just provides the ability to enter this second code without error

Note:
The aim is to make it work without two verification codes, in future PR.