### PR TITLE
Feat/#16 code input

### DIFF
--- a/app/confirm-signin.tsx
+++ b/app/confirm-signin.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import TextInput from '@/components/inputs/TextInput'
+import CodeInput from '@/components/inputs/CodeInput'
 import ContinueButton from '@/components/navigation/ContinueButton'
 import ScreenContent from '@/components/screen-layout/ScreenContent'
 import ScreenView from '@/components/screen-layout/ScreenView'
@@ -20,15 +20,7 @@ const Page = () => {
       <ScreenContent>
         <Typography variant="h1">{t('enterVerificationCode')}</Typography>
 
-        <TextInput
-          value={code}
-          onChangeText={setCode}
-          keyboardType="number-pad"
-          autoComplete="one-time-code"
-          textAlign="center"
-          autoFocus
-          onSubmitEditing={() => confirmSignIn(code)}
-        />
+        <CodeInput autoFocus value={code} setValue={setCode} onBlur={() => confirmSignIn(code)} />
 
         <Typography>{t('instructions')}</Typography>
 

--- a/app/examples/codeinput-example.tsx
+++ b/app/examples/codeinput-example.tsx
@@ -1,0 +1,17 @@
+import CodeInput from '@/components/inputs/CodeInput'
+import ScreenContent from '@/components/screen-layout/ScreenContent'
+import ScreenView from '@/components/screen-layout/ScreenView'
+import Typography from '@/components/shared/Typography'
+
+const CodeInputScreen = () => {
+  return (
+    <ScreenView>
+      <ScreenContent>
+        <Typography variant="h1">CodeInput</Typography>
+        <CodeInput />
+      </ScreenContent>
+    </ScreenView>
+  )
+}
+
+export default CodeInputScreen

--- a/app/examples/codeinput-example.tsx
+++ b/app/examples/codeinput-example.tsx
@@ -1,14 +1,18 @@
+import { useState } from 'react'
+
 import CodeInput from '@/components/inputs/CodeInput'
 import ScreenContent from '@/components/screen-layout/ScreenContent'
 import ScreenView from '@/components/screen-layout/ScreenView'
 import Typography from '@/components/shared/Typography'
 
 const CodeInputScreen = () => {
+  const [code, setCode] = useState('')
+
   return (
     <ScreenView>
       <ScreenContent>
         <Typography variant="h1">CodeInput</Typography>
-        <CodeInput />
+        <CodeInput value={code} setValue={setCode} onBlur={() => console.log('BLUR')} />
       </ScreenContent>
     </ScreenView>
   )

--- a/app/parking-cards/verification/index.tsx
+++ b/app/parking-cards/verification/index.tsx
@@ -33,13 +33,11 @@ const Page = () => {
       clientApi.verifiedEmailsControllerSendEmailVerificationEmails(bodyInner),
     onSuccess: (res) => {
       const tmpVerificationToken = res.data[0].token
-      const tmpVerificationKey = res.data[0].key
 
-      router.push({
+      router.replace({
         pathname: '/parking-cards/verification/verification-sent',
         params: {
-          emailToVerify: email,
-          tmpVerificationKey,
+          email,
           tmpVerificationToken,
         },
       })

--- a/app/parking-cards/verification/verification-result.tsx
+++ b/app/parking-cards/verification/verification-result.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { Link, router, Stack, useLocalSearchParams } from 'expo-router'
+import { Link, router, useLocalSearchParams } from 'expo-router'
 import React from 'react'
 
 import ContinueButton from '@/components/navigation/ContinueButton'
@@ -10,14 +10,11 @@ import { clientApi } from '@/modules/backend/client-api'
 import { verifiedEmailsOptions } from '@/modules/backend/constants/queryOptions'
 import { VerifyEmailsDto } from '@/modules/backend/openapi-generated'
 
-/**
- * This page handles redirects from BE to show email verification result.
- *
- * Do not change the path unless it's changed in BE as well!
- *
+/*
  * Figma: https://www.figma.com/file/3TppNabuUdnCChkHG9Vft7/paas-mpa?node-id=1300%3A11943&mode=dev
  */
 
+// TODO may need update depending on changes in figma
 type VerificationResultSearchParams = {
   email: string
   status: 'verified' | 'verified-no-cards' | 'link-expired'
@@ -34,17 +31,10 @@ const VerificationResultPage = () => {
   const mutation = useMutation({
     mutationFn: (bodyInner: VerifyEmailsDto) =>
       clientApi.verifiedEmailsControllerSendEmailVerificationEmails(bodyInner),
-    onSuccess: (res) => {
-      const tmpVerificationToken = res.data[0].token
-      const tmpVerificationKey = res.data[0].key
-
-      router.push({
+    onSuccess: () => {
+      router.replace({
         pathname: '/parking-cards/verification/verification-sent',
-        params: {
-          emailToVerify: email,
-          tmpVerificationKey,
-          tmpVerificationToken,
-        },
+        params: { email },
       })
     },
   })
@@ -71,7 +61,7 @@ const VerificationResultPage = () => {
         )
       }
     >
-      <Stack.Screen options={{ headerShown: false }} />
+      {/* <Stack.Screen options={{ headerShown: false }} /> */}
 
       {email && status ? (
         <ContentWithAvatar

--- a/app/parking-cards/verification/verification-sent.tsx
+++ b/app/parking-cards/verification/verification-sent.tsx
@@ -1,71 +1,52 @@
 import { useMutation } from '@tanstack/react-query'
-import { Link, router, useLocalSearchParams } from 'expo-router'
-import React from 'react'
+import { router, useLocalSearchParams } from 'expo-router'
+import React, { useState } from 'react'
 
 import { EmailAvatar } from '@/assets/avatars'
-import ContinueButton from '@/components/navigation/ContinueButton'
+import CodeInput from '@/components/inputs/CodeInput'
 import ContentWithAvatar from '@/components/screen-layout/ContentWithAvatar'
 import ScreenViewCentered from '@/components/screen-layout/ScreenViewCentered'
 import Button from '@/components/shared/Button'
+import Typography from '@/components/shared/Typography'
 import { useTranslation } from '@/hooks/useTranslation'
 import { clientApi } from '@/modules/backend/client-api'
-
-// TODO remove - this button simulates email verification
-const TmpVerifyButton = () => {
-  const { tmpVerificationToken, tmpVerificationKey, emailToVerify } = useLocalSearchParams<{
-    emailToVerify: string
-    tmpVerificationToken: string
-    tmpVerificationKey: string
-  }>()
-
-  const mutation = useMutation({
-    mutationFn: () =>
-      clientApi.verifiedEmailsControllerVerifyEmail(
-        tmpVerificationToken ?? '',
-        tmpVerificationKey ?? '',
-      ),
-  })
-
-  const handlePressVerify = () => {
-    mutation.mutate(undefined, {
-      onSuccess: (res) => {
-        console.log('success', res.status)
-        router.push({
-          pathname: '/parking-cards/verification/verification-result',
-          params: { email: emailToVerify, status: 'verified' },
-        })
-      },
-    })
-  }
-
-  return (
-    <Button variant="plain" onPress={handlePressVerify}>
-      Verify
-    </Button>
-  )
-}
 
 /*
  * Figma: https://www.figma.com/file/3TppNabuUdnCChkHG9Vft7/paas-(mobile-app)-%5BWIP%5D?node-id=4232%3A6109&mode=dev
  */
 const Page = () => {
   const t = useTranslation('AddParkingCards')
-  const { emailToVerify } = useLocalSearchParams()
+  const { email, tmpVerificationToken } = useLocalSearchParams()
+
+  const [code, setCode] = useState('')
+
+  // TODO handle expired token, token mismatch, add resend token button, etc.
+  const mutation = useMutation({
+    mutationFn: () => clientApi.verifiedEmailsControllerVerifyEmail(code),
+  })
+
+  const handleVerify = () => {
+    mutation.mutate(undefined, {
+      onSuccess: (res) => {
+        console.log('success', res.status)
+        router.replace({
+          pathname: '/parking-cards/verification/verification-result',
+          params: { email, status: 'verified' },
+        })
+      },
+    })
+  }
 
   return (
-    <ScreenViewCentered
-      actionButton={
-        <Link asChild href={{ pathname: '/parking-cards' }}>
-          <ContinueButton />
-        </Link>
-      }
-    >
+    <ScreenViewCentered actionButton={<Button onPress={handleVerify}>Verify</Button>}>
       <ContentWithAvatar
         title={t('verifyYourEmail')}
-        text={t('verifyYourEmailInfo', { email: emailToVerify })}
+        text={t('verifyYourEmailInfo', { email })}
         customAvatarComponent={<EmailAvatar />}
-        actionButton={<TmpVerifyButton />}
-      />
+      >
+        <Typography>{tmpVerificationToken}</Typography>
+        <CodeInput value={code} setValue={setCode} onBlur={handleVerify} />
+      </ContentWithAvatar>
     </ScreenViewCentered>
   )
 }

--- a/components/DeveloperMenu.tsx
+++ b/components/DeveloperMenu.tsx
@@ -56,6 +56,11 @@ const menuItems: MenuItem[] = [
     route: '/examples/snackbar-example',
   },
   {
+    title: 'Code input',
+    subtitle: 'Code input examples',
+    route: '/examples/codeinput-example',
+  },
+  {
     title: 'Purchase',
     subtitle: 'Whole flow of ticket purchase',
     route: '/purchase',

--- a/components/inputs/CodeInput.tsx
+++ b/components/inputs/CodeInput.tsx
@@ -1,0 +1,61 @@
+import clsx from 'clsx'
+import React, { useState } from 'react'
+import { StyleSheet } from 'react-native'
+import {
+  CodeField,
+  Cursor,
+  useBlurOnFulfill,
+  useClearByFocusCell,
+} from 'react-native-confirmation-code-field'
+
+import Typography from '@/components/shared/Typography'
+
+const CELL_COUNT = 6
+
+const styles = StyleSheet.create({
+  rootStyle: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+})
+
+const CodeInput = () => {
+  const [value, setValue] = useState('')
+
+  const ref = useBlurOnFulfill({ value, cellCount: CELL_COUNT })
+  const [props, getCellOnLayoutHandler] = useClearByFocusCell({
+    value,
+    setValue,
+  })
+
+  return (
+    <CodeField
+      ref={ref}
+      {...props}
+      // Use `caretHidden={false}` when users can't paste a text value, because context menu doesn't appear
+      value={value}
+      onChangeText={setValue}
+      cellCount={CELL_COUNT}
+      keyboardType="number-pad"
+      textContentType="oneTimeCode"
+      rootStyle={styles.rootStyle}
+      renderCell={({ index, symbol, isFocused }) => (
+        <Typography
+          key={index}
+          onLayout={getCellOnLayoutHandler(index)}
+          className={clsx(
+            'h-[48px] w-[48px] items-center justify-center rounded border border-divider bg-white text-center text-[20px] leading-[44px]',
+            {
+              'border-dark': isFocused,
+            },
+          )}
+        >
+          {symbol || (isFocused ? <Cursor /> : null)}
+        </Typography>
+      )}
+    />
+  )
+}
+
+export default CodeInput

--- a/components/inputs/CodeInput.tsx
+++ b/components/inputs/CodeInput.tsx
@@ -1,16 +1,15 @@
 import clsx from 'clsx'
-import React, { useState } from 'react'
+import React from 'react'
 import { StyleSheet } from 'react-native'
 import {
   CodeField,
+  CodeFieldProps,
   Cursor,
   useBlurOnFulfill,
   useClearByFocusCell,
 } from 'react-native-confirmation-code-field'
 
 import Typography from '@/components/shared/Typography'
-
-const CELL_COUNT = 6
 
 const styles = StyleSheet.create({
   rootStyle: {
@@ -20,11 +19,33 @@ const styles = StyleSheet.create({
   },
 })
 
-const CodeInput = () => {
-  const [value, setValue] = useState('')
-
-  const ref = useBlurOnFulfill({ value, cellCount: CELL_COUNT })
-  const [props, getCellOnLayoutHandler] = useClearByFocusCell({
+type CodeInputProps = Omit<
+  CodeFieldProps,
+  | 'renderCell'
+  | 'rootStyle'
+  | 'autoComplete'
+  | 'keyboardType'
+  | 'value'
+  | 'onChangeText'
+  | 'onSubmitEditing'
+> & {
+  value: string
+  setValue: (value: string) => void
+}
+/**
+ * Docs: https://github.com/retyui/react-native-confirmation-code-field/blob/c944750acb811d2cc7f2a45ae9e6982831297419/API.md
+ *
+ * Instead of `onSubmitEditing` use `onBlur` - field is automatically blured when fulfilled.
+ *
+ * @param cellCount
+ * @param value
+ * @param setValue
+ * @param props
+ * @constructor
+ */
+const CodeInput = ({ cellCount = 6, value, setValue, ...props }: CodeInputProps) => {
+  const ref = useBlurOnFulfill({ value, cellCount })
+  const [focusCellProps, getCellOnLayoutHandler] = useClearByFocusCell({
     value,
     setValue,
   })
@@ -33,17 +54,19 @@ const CodeInput = () => {
     <CodeField
       ref={ref}
       {...props}
+      {...focusCellProps}
       // Use `caretHidden={false}` when users can't paste a text value, because context menu doesn't appear
       value={value}
       onChangeText={setValue}
-      cellCount={CELL_COUNT}
+      cellCount={cellCount}
       keyboardType="number-pad"
-      textContentType="oneTimeCode"
+      autoComplete="one-time-code"
       rootStyle={styles.rootStyle}
       renderCell={({ index, symbol, isFocused }) => (
         <Typography
           key={index}
           onLayout={getCellOnLayoutHandler(index)}
+          // TODO - sizes are little bit guessed, needs to be tested on multiple devices
           className={clsx(
             'h-[48px] w-[48px] items-center justify-center rounded border border-divider bg-white text-center text-[20px] leading-[44px]',
             {

--- a/components/tickets/PurchaseBottomSheet.tsx
+++ b/components/tickets/PurchaseBottomSheet.tsx
@@ -39,13 +39,6 @@ const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(
 
     const durationFromPriceDate = getDurationFromPriceData(priceData)
 
-    const body: InitiatePaymentRequestDto = {
-      ticket: priceRequestBody,
-      price: priceData?.priceTotal ?? 0,
-      priceBpk: priceData?.creditBpkUsed ?? '',
-      priceNpk: priceData?.creditNpkUsed ?? '',
-    }
-
     const mutation = useMutation({
       mutationFn: (bodyInner: InitiatePaymentRequestDto) =>
         clientApi.ticketsControllerInitiateTicketPayment(bodyInner),
@@ -53,7 +46,7 @@ const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(
 
     // eslint-disable-next-line unicorn/consistent-function-scoping
     const handlePressPay = () => {
-      mutation.mutate(body, {
+      mutation.mutate(priceRequestBody, {
         onSuccess: (data) => {
           console.log('onSuccess', JSON.stringify(data.data, undefined, 2))
           router.push({

--- a/modules/backend/openapi-generated/api.ts
+++ b/modules/backend/openapi-generated/api.ts
@@ -179,13 +179,6 @@ export interface EmailVerificationResult {
    * @deprecated
    */
   token: string
-  /**
-   * Key which is sent to the email - only avaialble for test purposes
-   * @type {string}
-   * @memberof EmailVerificationResult
-   * @deprecated
-   */
-  key: string
 }
 /**
  *
@@ -282,11 +275,23 @@ export interface GetTicketPriceResponseDto {
    */
   creditBpkUsed: string
   /**
+   * Credits used in case of bonnus parking in seconds
+   * @type {number}
+   * @memberof GetTicketPriceResponseDto
+   */
+  creditBpkUsedSeconds: number
+  /**
    * NPK - Bonus minutes used (PT means \'Period of Time\'. The time format is standardized according to ISO 8601. For example PT1H30M15S - 1 hour 30 minutes 15 seconds.)
    * @type {string}
    * @memberof GetTicketPriceResponseDto
    */
   creditNpkUsed: string
+  /**
+   * Credits used in case of bonnus parking in seconds
+   * @type {number}
+   * @memberof GetTicketPriceResponseDto
+   */
+  creditNpkUsedSeconds: number
   /**
    * The date and time when parking starts (UTC time in ISO8601 format)
    * @type {string}
@@ -341,7 +346,7 @@ export interface GetTicketPriceTicketInfoRequestDto {
    * @type {string}
    * @memberof GetTicketPriceTicketInfoRequestDto
    */
-  parkingStart?: string
+  parkingStart: string
 }
 /**
  *
@@ -369,29 +374,17 @@ export interface GetTicketProlongationPriceRequestDto {
  */
 export interface InitiatePaymentRequestDto {
   /**
+   * Value of NPK UUID
+   * @type {string}
+   * @memberof InitiatePaymentRequestDto
+   */
+  npkId?: string
+  /**
    *
-   * @type {GetTicketPriceRequestDto}
+   * @type {GetTicketPriceTicketInfoRequestDto}
    * @memberof InitiatePaymentRequestDto
    */
-  ticket: GetTicketPriceRequestDto
-  /**
-   * Price coming from the FE what the user seen last time and accepted to pay for the ticket
-   * @type {number}
-   * @memberof InitiatePaymentRequestDto
-   */
-  price: number
-  /**
-   * Price coming from the FE what the user seen last time and accepted to pay for the ticket from the BPK credit (PT means \'Period of Time\'. The time format is standardized according to ISO 8601. For example PT1H30M15S - 1 hour 30 minutes 15 seconds.)
-   * @type {string}
-   * @memberof InitiatePaymentRequestDto
-   */
-  priceBpk: string
-  /**
-   * Price coming from the FE what the user seen last time and accepted to pay for the ticket from the NPK credit (PT means \'Period of Time\'. The time format is standardized according to ISO 8601. For example PT1H30M15S - 1 hour 30 minutes 15 seconds.)
-   * @type {string}
-   * @memberof InitiatePaymentRequestDto
-   */
-  priceNpk: string
+  ticket: GetTicketPriceTicketInfoRequestDto
 }
 /**
  *
@@ -400,29 +393,17 @@ export interface InitiatePaymentRequestDto {
  */
 export interface InitiateProlongationRequestDto {
   /**
-   *
-   * @type {GetTicketProlongationPriceRequestDto}
+   * The date and time when parking ends (UTC time in ISO8601 format)
+   * @type {string}
    * @memberof InitiateProlongationRequestDto
    */
-  ticket: GetTicketProlongationPriceRequestDto
+  newParkingEnd: string
   /**
-   * Price coming from the FE what the user seen last time and accepted to pay for the ticket
+   * Id of the ticket to be prolonged
    * @type {number}
    * @memberof InitiateProlongationRequestDto
    */
-  price: number
-  /**
-   * Price coming from the FE what the user seen last time and accepted to pay for the ticket from the BPK credit (PT means \'Period of Time\'. The time format is standardized according to ISO 8601. For example PT1H30M15S - 1 hour 30 minutes 15 seconds.)
-   * @type {string}
-   * @memberof InitiateProlongationRequestDto
-   */
-  priceBpk: string
-  /**
-   * Price coming from the FE what the user seen last time and accepted to pay for the ticket from the NPK credit (PT means \'Period of Time\'. The time format is standardized according to ISO 8601. For example PT1H30M15S - 1 hour 30 minutes 15 seconds.)
-   * @type {string}
-   * @memberof InitiateProlongationRequestDto
-   */
-  priceNpk: string
+  ticketId: number
 }
 /**
  *
@@ -574,11 +555,23 @@ export interface ParkingCardDto {
    */
   balance?: string
   /**
-   * Balance available on the visitor card (PT means \'Period of Time\'. The time format is standardized according to ISO 8601. For example PT1H30M15S - 1 hour 30 minutes 15 seconds.)
+   * Balance available on the visitor card in seconds
+   * @type {number}
+   * @memberof ParkingCardDto
+   */
+  balanceSeconds?: number
+  /**
+   * Original balance available on the visitor card (PT means \'Period of Time\'. The time format is standardized according to ISO 8601. For example PT1H30M15S - 1 hour 30 minutes 15 seconds.)
    * @type {string}
    * @memberof ParkingCardDto
    */
   originalBalance?: string
+  /**
+   * Original balance available on the visitor card in seconds
+   * @type {number}
+   * @memberof ParkingCardDto
+   */
+  originalBalanceSeconds?: number
   /**
    * List of Internal ids of the parking space.
    * @type {Array<string>}
@@ -635,55 +628,6 @@ export interface ParkingCardsResponseDto {
    * @memberof ParkingCardsResponseDto
    */
   paginationInfo: PaginationInfo
-}
-/**
- *
- * @export
- * @interface PaymentResponseQueryDto
- */
-export interface PaymentResponseQueryDto {
-  /**
-   * Operation text coming from the paygate return url query param
-   * @type {string}
-   * @memberof PaymentResponseQueryDto
-   */
-  OPERATION: string
-  /**
-   * Ordernumber text coming from the paygate return url query param (13 characters long number)
-   * @type {string}
-   * @memberof PaymentResponseQueryDto
-   */
-  ORDERNUMBER: string
-  /**
-   * Prcode text coming from the paygate return url query param
-   * @type {string}
-   * @memberof PaymentResponseQueryDto
-   */
-  PRCODE: string
-  /**
-   * Srcode text coming from the paygate return url query param
-   * @type {string}
-   * @memberof PaymentResponseQueryDto
-   */
-  SRCODE: string
-  /**
-   * Digest text coming from the paygate return url query param
-   * @type {string}
-   * @memberof PaymentResponseQueryDto
-   */
-  DIGEST: string
-  /**
-   * Digest1 text coming from the paygate return url query param
-   * @type {string}
-   * @memberof PaymentResponseQueryDto
-   */
-  DIGEST1: string
-  /**
-   * Result text coming from the paygate return url query param
-   * @type {string}
-   * @memberof PaymentResponseQueryDto
-   */
-  RESULTTEXT: string
 }
 /**
  *
@@ -919,11 +863,23 @@ export interface TicketDto {
    */
   bpkCreditUsed?: string
   /**
+   * Credits used in case of bonnus parking in seconds
+   * @type {number}
+   * @memberof TicketDto
+   */
+  bpkCreditUsedSeconds: number
+  /**
    * Credits used in case of visitor parking (PT means \'Period of Time\'. The time format is standardized according to ISO 8601. For example PT1H30M15S - 1 hour 30 minutes 15 seconds.)
    * @type {string}
    * @memberof TicketDto
    */
   npkCreditUsed?: string
+  /**
+   * Credits used in case of visitor parking in seconds
+   * @type {number}
+   * @memberof TicketDto
+   */
+  npkCreditUsedSeconds: number
   /**
    * ID of the visitor card (GUID)
    * @type {string}
@@ -1347,10 +1303,6 @@ export const AnnouncementsApiAxiosParamCreator = function (configuration?: Confi
       const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options }
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
-
-      // authentication azure required
-      // http bearer authentication required
-      await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
       localVarHeaderParameter['Content-Type'] = 'application/json'
 
@@ -2607,21 +2559,41 @@ export const TicketsApiAxiosParamCreator = function (configuration?: Configurati
     },
     /**
      *
-     * @summary Process ticket payment
-     * @param {PaymentResponseQueryDto} paymentResponseQueryDto
+     * @summary Process ticket payment. This endpoint is called by the payment gate.
+     * @param {string} oPERATION Operation text coming from the paygate return url query param
+     * @param {string} oRDERNUMBER Ordernumber text coming from the paygate return url query param (13 characters long number)
+     * @param {string} pRCODE Prcode text coming from the paygate return url query param
+     * @param {string} sRCODE Srcode text coming from the paygate return url query param
+     * @param {string} dIGEST Digest text coming from the paygate return url query param
+     * @param {string} dIGEST1 Digest1 text coming from the paygate return url query param
+     * @param {string} rESULTTEXT Result text coming from the paygate return url query param
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     ticketsControllerProcessTicketPayment: async (
-      paymentResponseQueryDto: PaymentResponseQueryDto,
+      oPERATION: string,
+      oRDERNUMBER: string,
+      pRCODE: string,
+      sRCODE: string,
+      dIGEST: string,
+      dIGEST1: string,
+      rESULTTEXT: string,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'paymentResponseQueryDto' is not null or undefined
-      assertParamExists(
-        'ticketsControllerProcessTicketPayment',
-        'paymentResponseQueryDto',
-        paymentResponseQueryDto,
-      )
+      // verify required parameter 'oPERATION' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketPayment', 'oPERATION', oPERATION)
+      // verify required parameter 'oRDERNUMBER' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketPayment', 'oRDERNUMBER', oRDERNUMBER)
+      // verify required parameter 'pRCODE' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketPayment', 'pRCODE', pRCODE)
+      // verify required parameter 'sRCODE' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketPayment', 'sRCODE', sRCODE)
+      // verify required parameter 'dIGEST' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketPayment', 'dIGEST', dIGEST)
+      // verify required parameter 'dIGEST1' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketPayment', 'dIGEST1', dIGEST1)
+      // verify required parameter 'rESULTTEXT' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketPayment', 'rESULTTEXT', rESULTTEXT)
       const localVarPath = `/tickets/payment/process`
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
@@ -2630,15 +2602,37 @@ export const TicketsApiAxiosParamCreator = function (configuration?: Configurati
         baseOptions = configuration.baseOptions
       }
 
-      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options }
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options }
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      // authentication cognito required
-      // http bearer authentication required
-      await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      if (oPERATION !== undefined) {
+        localVarQueryParameter['OPERATION'] = oPERATION
+      }
 
-      localVarHeaderParameter['Content-Type'] = 'application/json'
+      if (oRDERNUMBER !== undefined) {
+        localVarQueryParameter['ORDERNUMBER'] = oRDERNUMBER
+      }
+
+      if (pRCODE !== undefined) {
+        localVarQueryParameter['PRCODE'] = pRCODE
+      }
+
+      if (sRCODE !== undefined) {
+        localVarQueryParameter['SRCODE'] = sRCODE
+      }
+
+      if (dIGEST !== undefined) {
+        localVarQueryParameter['DIGEST'] = dIGEST
+      }
+
+      if (dIGEST1 !== undefined) {
+        localVarQueryParameter['DIGEST1'] = dIGEST1
+      }
+
+      if (rESULTTEXT !== undefined) {
+        localVarQueryParameter['RESULTTEXT'] = rESULTTEXT
+      }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
@@ -2647,11 +2641,6 @@ export const TicketsApiAxiosParamCreator = function (configuration?: Configurati
         ...headersFromBaseOptions,
         ...options.headers,
       }
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        paymentResponseQueryDto,
-        localVarRequestOptions,
-        configuration,
-      )
 
       return {
         url: toPathString(localVarUrlObj),
@@ -2660,20 +2649,48 @@ export const TicketsApiAxiosParamCreator = function (configuration?: Configurati
     },
     /**
      *
-     * @summary Process ticket prolongation payment
-     * @param {PaymentResponseQueryDto} paymentResponseQueryDto
+     * @summary Process ticket prolongation payment. This endpoint is called by the payment gate.
+     * @param {string} oPERATION Operation text coming from the paygate return url query param
+     * @param {string} oRDERNUMBER Ordernumber text coming from the paygate return url query param (13 characters long number)
+     * @param {string} pRCODE Prcode text coming from the paygate return url query param
+     * @param {string} sRCODE Srcode text coming from the paygate return url query param
+     * @param {string} dIGEST Digest text coming from the paygate return url query param
+     * @param {string} dIGEST1 Digest1 text coming from the paygate return url query param
+     * @param {string} rESULTTEXT Result text coming from the paygate return url query param
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     ticketsControllerProcessTicketProlongationPayment: async (
-      paymentResponseQueryDto: PaymentResponseQueryDto,
+      oPERATION: string,
+      oRDERNUMBER: string,
+      pRCODE: string,
+      sRCODE: string,
+      dIGEST: string,
+      dIGEST1: string,
+      rESULTTEXT: string,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'paymentResponseQueryDto' is not null or undefined
+      // verify required parameter 'oPERATION' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketProlongationPayment', 'oPERATION', oPERATION)
+      // verify required parameter 'oRDERNUMBER' is not null or undefined
       assertParamExists(
         'ticketsControllerProcessTicketProlongationPayment',
-        'paymentResponseQueryDto',
-        paymentResponseQueryDto,
+        'oRDERNUMBER',
+        oRDERNUMBER,
+      )
+      // verify required parameter 'pRCODE' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketProlongationPayment', 'pRCODE', pRCODE)
+      // verify required parameter 'sRCODE' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketProlongationPayment', 'sRCODE', sRCODE)
+      // verify required parameter 'dIGEST' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketProlongationPayment', 'dIGEST', dIGEST)
+      // verify required parameter 'dIGEST1' is not null or undefined
+      assertParamExists('ticketsControllerProcessTicketProlongationPayment', 'dIGEST1', dIGEST1)
+      // verify required parameter 'rESULTTEXT' is not null or undefined
+      assertParamExists(
+        'ticketsControllerProcessTicketProlongationPayment',
+        'rESULTTEXT',
+        rESULTTEXT,
       )
       const localVarPath = `/tickets/payment/prolongation/process`
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -2683,15 +2700,37 @@ export const TicketsApiAxiosParamCreator = function (configuration?: Configurati
         baseOptions = configuration.baseOptions
       }
 
-      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options }
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options }
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      // authentication cognito required
-      // http bearer authentication required
-      await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      if (oPERATION !== undefined) {
+        localVarQueryParameter['OPERATION'] = oPERATION
+      }
 
-      localVarHeaderParameter['Content-Type'] = 'application/json'
+      if (oRDERNUMBER !== undefined) {
+        localVarQueryParameter['ORDERNUMBER'] = oRDERNUMBER
+      }
+
+      if (pRCODE !== undefined) {
+        localVarQueryParameter['PRCODE'] = pRCODE
+      }
+
+      if (sRCODE !== undefined) {
+        localVarQueryParameter['SRCODE'] = sRCODE
+      }
+
+      if (dIGEST !== undefined) {
+        localVarQueryParameter['DIGEST'] = dIGEST
+      }
+
+      if (dIGEST1 !== undefined) {
+        localVarQueryParameter['DIGEST1'] = dIGEST1
+      }
+
+      if (rESULTTEXT !== undefined) {
+        localVarQueryParameter['RESULTTEXT'] = rESULTTEXT
+      }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
@@ -2700,11 +2739,6 @@ export const TicketsApiAxiosParamCreator = function (configuration?: Configurati
         ...headersFromBaseOptions,
         ...options.headers,
       }
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        paymentResponseQueryDto,
-        localVarRequestOptions,
-        configuration,
-      )
 
       return {
         url: toPathString(localVarUrlObj),
@@ -2898,36 +2932,72 @@ export const TicketsApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @summary Process ticket payment
-     * @param {PaymentResponseQueryDto} paymentResponseQueryDto
+     * @summary Process ticket payment. This endpoint is called by the payment gate.
+     * @param {string} oPERATION Operation text coming from the paygate return url query param
+     * @param {string} oRDERNUMBER Ordernumber text coming from the paygate return url query param (13 characters long number)
+     * @param {string} pRCODE Prcode text coming from the paygate return url query param
+     * @param {string} sRCODE Srcode text coming from the paygate return url query param
+     * @param {string} dIGEST Digest text coming from the paygate return url query param
+     * @param {string} dIGEST1 Digest1 text coming from the paygate return url query param
+     * @param {string} rESULTTEXT Result text coming from the paygate return url query param
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async ticketsControllerProcessTicketPayment(
-      paymentResponseQueryDto: PaymentResponseQueryDto,
+      oPERATION: string,
+      oRDERNUMBER: string,
+      pRCODE: string,
+      sRCODE: string,
+      dIGEST: string,
+      dIGEST1: string,
+      rESULTTEXT: string,
       options?: AxiosRequestConfig,
-    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TicketDto>> {
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.ticketsControllerProcessTicketPayment(
-          paymentResponseQueryDto,
+          oPERATION,
+          oRDERNUMBER,
+          pRCODE,
+          sRCODE,
+          dIGEST,
+          dIGEST1,
+          rESULTTEXT,
           options,
         )
       return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)
     },
     /**
      *
-     * @summary Process ticket prolongation payment
-     * @param {PaymentResponseQueryDto} paymentResponseQueryDto
+     * @summary Process ticket prolongation payment. This endpoint is called by the payment gate.
+     * @param {string} oPERATION Operation text coming from the paygate return url query param
+     * @param {string} oRDERNUMBER Ordernumber text coming from the paygate return url query param (13 characters long number)
+     * @param {string} pRCODE Prcode text coming from the paygate return url query param
+     * @param {string} sRCODE Srcode text coming from the paygate return url query param
+     * @param {string} dIGEST Digest text coming from the paygate return url query param
+     * @param {string} dIGEST1 Digest1 text coming from the paygate return url query param
+     * @param {string} rESULTTEXT Result text coming from the paygate return url query param
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async ticketsControllerProcessTicketProlongationPayment(
-      paymentResponseQueryDto: PaymentResponseQueryDto,
+      oPERATION: string,
+      oRDERNUMBER: string,
+      pRCODE: string,
+      sRCODE: string,
+      dIGEST: string,
+      dIGEST1: string,
+      rESULTTEXT: string,
       options?: AxiosRequestConfig,
-    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TicketDto>> {
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.ticketsControllerProcessTicketProlongationPayment(
-          paymentResponseQueryDto,
+          oPERATION,
+          oRDERNUMBER,
+          pRCODE,
+          sRCODE,
+          dIGEST,
+          dIGEST1,
+          rESULTTEXT,
           options,
         )
       return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)
@@ -3048,32 +3118,74 @@ export const TicketsApiFactory = function (
     },
     /**
      *
-     * @summary Process ticket payment
-     * @param {PaymentResponseQueryDto} paymentResponseQueryDto
+     * @summary Process ticket payment. This endpoint is called by the payment gate.
+     * @param {string} oPERATION Operation text coming from the paygate return url query param
+     * @param {string} oRDERNUMBER Ordernumber text coming from the paygate return url query param (13 characters long number)
+     * @param {string} pRCODE Prcode text coming from the paygate return url query param
+     * @param {string} sRCODE Srcode text coming from the paygate return url query param
+     * @param {string} dIGEST Digest text coming from the paygate return url query param
+     * @param {string} dIGEST1 Digest1 text coming from the paygate return url query param
+     * @param {string} rESULTTEXT Result text coming from the paygate return url query param
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     ticketsControllerProcessTicketPayment(
-      paymentResponseQueryDto: PaymentResponseQueryDto,
+      oPERATION: string,
+      oRDERNUMBER: string,
+      pRCODE: string,
+      sRCODE: string,
+      dIGEST: string,
+      dIGEST1: string,
+      rESULTTEXT: string,
       options?: AxiosRequestConfig,
-    ): AxiosPromise<TicketDto> {
+    ): AxiosPromise<void> {
       return localVarFp
-        .ticketsControllerProcessTicketPayment(paymentResponseQueryDto, options)
+        .ticketsControllerProcessTicketPayment(
+          oPERATION,
+          oRDERNUMBER,
+          pRCODE,
+          sRCODE,
+          dIGEST,
+          dIGEST1,
+          rESULTTEXT,
+          options,
+        )
         .then((request) => request(axios, basePath))
     },
     /**
      *
-     * @summary Process ticket prolongation payment
-     * @param {PaymentResponseQueryDto} paymentResponseQueryDto
+     * @summary Process ticket prolongation payment. This endpoint is called by the payment gate.
+     * @param {string} oPERATION Operation text coming from the paygate return url query param
+     * @param {string} oRDERNUMBER Ordernumber text coming from the paygate return url query param (13 characters long number)
+     * @param {string} pRCODE Prcode text coming from the paygate return url query param
+     * @param {string} sRCODE Srcode text coming from the paygate return url query param
+     * @param {string} dIGEST Digest text coming from the paygate return url query param
+     * @param {string} dIGEST1 Digest1 text coming from the paygate return url query param
+     * @param {string} rESULTTEXT Result text coming from the paygate return url query param
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     ticketsControllerProcessTicketProlongationPayment(
-      paymentResponseQueryDto: PaymentResponseQueryDto,
+      oPERATION: string,
+      oRDERNUMBER: string,
+      pRCODE: string,
+      sRCODE: string,
+      dIGEST: string,
+      dIGEST1: string,
+      rESULTTEXT: string,
       options?: AxiosRequestConfig,
-    ): AxiosPromise<TicketDto> {
+    ): AxiosPromise<void> {
       return localVarFp
-        .ticketsControllerProcessTicketProlongationPayment(paymentResponseQueryDto, options)
+        .ticketsControllerProcessTicketProlongationPayment(
+          oPERATION,
+          oRDERNUMBER,
+          pRCODE,
+          sRCODE,
+          dIGEST,
+          dIGEST1,
+          rESULTTEXT,
+          options,
+        )
         .then((request) => request(axios, basePath))
     },
     /**
@@ -3190,35 +3302,77 @@ export class TicketsApi extends BaseAPI {
 
   /**
    *
-   * @summary Process ticket payment
-   * @param {PaymentResponseQueryDto} paymentResponseQueryDto
+   * @summary Process ticket payment. This endpoint is called by the payment gate.
+   * @param {string} oPERATION Operation text coming from the paygate return url query param
+   * @param {string} oRDERNUMBER Ordernumber text coming from the paygate return url query param (13 characters long number)
+   * @param {string} pRCODE Prcode text coming from the paygate return url query param
+   * @param {string} sRCODE Srcode text coming from the paygate return url query param
+   * @param {string} dIGEST Digest text coming from the paygate return url query param
+   * @param {string} dIGEST1 Digest1 text coming from the paygate return url query param
+   * @param {string} rESULTTEXT Result text coming from the paygate return url query param
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof TicketsApi
    */
   public ticketsControllerProcessTicketPayment(
-    paymentResponseQueryDto: PaymentResponseQueryDto,
+    oPERATION: string,
+    oRDERNUMBER: string,
+    pRCODE: string,
+    sRCODE: string,
+    dIGEST: string,
+    dIGEST1: string,
+    rESULTTEXT: string,
     options?: AxiosRequestConfig,
   ) {
     return TicketsApiFp(this.configuration)
-      .ticketsControllerProcessTicketPayment(paymentResponseQueryDto, options)
+      .ticketsControllerProcessTicketPayment(
+        oPERATION,
+        oRDERNUMBER,
+        pRCODE,
+        sRCODE,
+        dIGEST,
+        dIGEST1,
+        rESULTTEXT,
+        options,
+      )
       .then((request) => request(this.axios, this.basePath))
   }
 
   /**
    *
-   * @summary Process ticket prolongation payment
-   * @param {PaymentResponseQueryDto} paymentResponseQueryDto
+   * @summary Process ticket prolongation payment. This endpoint is called by the payment gate.
+   * @param {string} oPERATION Operation text coming from the paygate return url query param
+   * @param {string} oRDERNUMBER Ordernumber text coming from the paygate return url query param (13 characters long number)
+   * @param {string} pRCODE Prcode text coming from the paygate return url query param
+   * @param {string} sRCODE Srcode text coming from the paygate return url query param
+   * @param {string} dIGEST Digest text coming from the paygate return url query param
+   * @param {string} dIGEST1 Digest1 text coming from the paygate return url query param
+   * @param {string} rESULTTEXT Result text coming from the paygate return url query param
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof TicketsApi
    */
   public ticketsControllerProcessTicketProlongationPayment(
-    paymentResponseQueryDto: PaymentResponseQueryDto,
+    oPERATION: string,
+    oRDERNUMBER: string,
+    pRCODE: string,
+    sRCODE: string,
+    dIGEST: string,
+    dIGEST1: string,
+    rESULTTEXT: string,
     options?: AxiosRequestConfig,
   ) {
     return TicketsApiFp(this.configuration)
-      .ticketsControllerProcessTicketProlongationPayment(paymentResponseQueryDto, options)
+      .ticketsControllerProcessTicketProlongationPayment(
+        oPERATION,
+        oRDERNUMBER,
+        pRCODE,
+        sRCODE,
+        dIGEST,
+        dIGEST1,
+        rESULTTEXT,
+        options,
+      )
       .then((request) => request(this.axios, this.basePath))
   }
 
@@ -4173,19 +4327,15 @@ export const VerifiedEmailsApiAxiosParamCreator = function (configuration?: Conf
      *
      * @summary Verifies an email with token
      * @param {string} token
-     * @param {string} key
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     verifiedEmailsControllerVerifyEmail: async (
       token: string,
-      key: string,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'token' is not null or undefined
       assertParamExists('verifiedEmailsControllerVerifyEmail', 'token', token)
-      // verify required parameter 'key' is not null or undefined
-      assertParamExists('verifiedEmailsControllerVerifyEmail', 'key', key)
       const localVarPath = `/verified-emails/verify`
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
@@ -4198,12 +4348,12 @@ export const VerifiedEmailsApiAxiosParamCreator = function (configuration?: Conf
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
+      // authentication cognito required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
       if (token !== undefined) {
         localVarQueryParameter['token'] = token
-      }
-
-      if (key !== undefined) {
-        localVarQueryParameter['key'] = key
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -4328,18 +4478,15 @@ export const VerifiedEmailsApiFp = function (configuration?: Configuration) {
      *
      * @summary Verifies an email with token
      * @param {string} token
-     * @param {string} key
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async verifiedEmailsControllerVerifyEmail(
       token: string,
-      key: string,
       options?: AxiosRequestConfig,
     ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<ParkingCardDto>>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.verifiedEmailsControllerVerifyEmail(
         token,
-        key,
         options,
       )
       return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)
@@ -4441,17 +4588,15 @@ export const VerifiedEmailsApiFactory = function (
      *
      * @summary Verifies an email with token
      * @param {string} token
-     * @param {string} key
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     verifiedEmailsControllerVerifyEmail(
       token: string,
-      key: string,
       options?: AxiosRequestConfig,
     ): AxiosPromise<Array<ParkingCardDto>> {
       return localVarFp
-        .verifiedEmailsControllerVerifyEmail(token, key, options)
+        .verifiedEmailsControllerVerifyEmail(token, options)
         .then((request) => request(axios, basePath))
     },
   }
@@ -4552,18 +4697,13 @@ export class VerifiedEmailsApi extends BaseAPI {
    *
    * @summary Verifies an email with token
    * @param {string} token
-   * @param {string} key
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof VerifiedEmailsApi
    */
-  public verifiedEmailsControllerVerifyEmail(
-    token: string,
-    key: string,
-    options?: AxiosRequestConfig,
-  ) {
+  public verifiedEmailsControllerVerifyEmail(token: string, options?: AxiosRequestConfig) {
     return VerifiedEmailsApiFp(this.configuration)
-      .verifiedEmailsControllerVerifyEmail(token, key, options)
+      .verifiedEmailsControllerVerifyEmail(token, options)
       .then((request) => request(this.axios, this.basePath))
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react": "18.2.0",
     "react-i18next": "~13.2.2",
     "react-native": "0.72.6",
+    "react-native-confirmation-code-field": "^7.3.2",
     "react-native-date-picker": "~4.3.3",
     "react-native-gesture-handler": "~2.12.0",
     "react-native-markdown-display": "~7.0.0-alpha.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10703,6 +10703,11 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-native-confirmation-code-field@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-confirmation-code-field/-/react-native-confirmation-code-field-7.3.2.tgz#f0ee9e72f632aa2ae4dade4a1664a7a484885ea8"
+  integrity sha512-uuJKxR+pQrXSx8lmRpekA+Hlle/nkoQKppS8jH7ApqY00+c11nCJg9kuFM0++vdbXg1rKm2P6jPZoSEJK2EaKw==
+
 react-native-date-picker@~4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/react-native-date-picker/-/react-native-date-picker-4.3.3.tgz#5ca4ca10283538ab9307b7f2dc6b83233ded122b"


### PR DESCRIPTION
- implement `CodeInput` based on `react-native-confirmation-code-field`
- use `CodeInput` on `confirm-signin` screen
- regenerate api and update FE accordingly
- use `CodeInput` in email verification process

Note
- It would be probably better to implement inner state by some `useControlledState` hook, instead of forcing us to pass `value` and `setValue` props, but we can implement it if it causes some issues.
- `CodeInput` needs to be tested properly, mainly on smaller screen.
- Whole email verification flow will be updated when figma is ready for verification with code instead of link
  - We still display verification code also on FE, for easier development

![image](https://github.com/bratislava/paas-mpa/assets/19418224/0e5bcedd-8754-4d69-84a4-ea5c48c5944d)
