### PR TITLE
Fix: quickfix EmptyStateScreen + minor updates

### DIFF
--- a/app/announcements/index.tsx
+++ b/app/announcements/index.tsx
@@ -56,7 +56,7 @@ const AnnouncementsScreen = () => {
   }
 
   if (data.announcements.length === 0) {
-    return <EmptyStateScreen title={t('noAnnouncementsTitle')} />
+    return <EmptyStateScreen contentTitle={t('noAnnouncementsTitle')} />
   }
 
   return (

--- a/app/examples/empty-state-example.tsx
+++ b/app/examples/empty-state-example.tsx
@@ -5,10 +5,10 @@ import EmptyStateScreen from '@/components/screen-layout/EmptyStateScreen'
 
 const EmptyStateExampleScreen = () => (
   <EmptyStateScreen
-    title="No entities"
+    contentTitle="No entities"
     text="This is an empty state with quite long text to see how it looks like."
-    button={<ContinueButton />}
-    buttonPosition="insideContent"
+    actionButton={<ContinueButton />}
+    actionButtonPosition="insideContent"
   />
 )
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -112,7 +112,7 @@ const IndexScreen = () => {
       <View className="absolute right-0 px-2.5 g-3" style={{ top }}>
         <View>
           <IconButton
-            name="menu"
+            name="more-vert"
             // TODO translation
             accessibilityLabel="Open menu"
             variant="white-raised-small"

--- a/app/parking-cards/[email].tsx
+++ b/app/parking-cards/[email].tsx
@@ -40,7 +40,7 @@ const Active = () => {
   const cards = data.parkingCards
 
   if (cards.length === 0) {
-    return <EmptyStateScreen title={t('noActiveCardsTitle')} text={t('noActiveCardsText')} />
+    return <EmptyStateScreen contentTitle={t('noActiveCardsTitle')} text={t('noActiveCardsText')} />
   }
 
   // TODO pagination

--- a/app/parking-cards/index.tsx
+++ b/app/parking-cards/index.tsx
@@ -31,14 +31,14 @@ const Page = () => {
   if (data.verifiedEmails.length === 0) {
     return (
       <EmptyStateScreen
-        title={t('noEmailsTitle')}
+        contentTitle={t('noEmailsTitle')}
         text={t('noEmailsText')}
-        button={
+        actionButton={
           <Link asChild href="/parking-cards/verification">
             <Button>{t('addParkingCards')}</Button>
           </Link>
         }
-        buttonPosition="insideContent"
+        actionButtonPosition="insideContent"
       />
     )
   }

--- a/app/tickets/index.tsx
+++ b/app/tickets/index.tsx
@@ -1,13 +1,12 @@
-import clsx from 'clsx'
 import { useCallback, useState } from 'react'
 import { FlatList, ListRenderItem, useWindowDimensions, View } from 'react-native'
 import { SceneMap, TabView } from 'react-native-tab-view'
 
-import { EmptyStateAvatar } from '@/assets/avatars'
 import TabBar from '@/components/navigation/TabBar'
-import ModalContentWithActions from '@/components/screen-layout/Modal/ModalContentWithActions'
+import EmptyStateScreen from '@/components/screen-layout/EmptyStateScreen'
 import ScreenContent from '@/components/screen-layout/ScreenContent'
 import ScreenView from '@/components/screen-layout/ScreenView'
+import Button from '@/components/shared/Button'
 import TicketCard from '@/components/tickets/TicketCard'
 import { useQueryWithFocusRefetch } from '@/hooks/useQueryWithFocusRefetch'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -15,50 +14,41 @@ import { ticketsOptions } from '@/modules/backend/constants/queryOptions'
 import { TicketDto } from '@/modules/backend/openapi-generated'
 
 const ActiveTicketsRoute = () => {
+  const t = useTranslation('Tickets')
+
   const { data: ticketsResponse } = useQueryWithFocusRefetch(ticketsOptions({ active: true }))
+  const { tickets } = ticketsResponse ?? {}
+
   const renderItem: ListRenderItem<TicketDto> = useCallback(
     ({ item }) => <TicketCard ticket={item} />,
     [],
   )
 
-  const tickets = ticketsResponse?.tickets
-
-  const isShowingTickets = tickets && tickets.length > 0
+  if (!tickets?.length) {
+    return (
+      <EmptyStateScreen
+        contentTitle={t('noActiveTickets')}
+        text={t('noActiveTicketsText')}
+        actionButton={<Button variant="primary">{t('buyTicket')}</Button>}
+      />
+    )
+  }
 
   return (
-    <ScreenContent
-      className={clsx('h-full px-0', !isShowingTickets && 'justify-center bg-transparent')}
-    >
-      {isShowingTickets ? (
-        <View className="h-full bg-white px-5">
-          <FlatList
-            // eslint-disable-next-line react-native/no-inline-styles
-            contentContainerStyle={{ gap: 12 }}
-            data={tickets}
-            renderItem={renderItem}
-          />
-        </View>
-      ) : (
-        <ModalContentWithActions
-          variant="success"
-          title="No active tickets"
-          text="Blababalalalabablal"
-          primaryActionLabel="Buy a ticket"
-          primaryActionOnPress={() => false}
-          customAvatarComponent={
-            <View className="w-full items-center">
-              <EmptyStateAvatar />
-            </View>
-          }
-          className="bg-white"
-        />
-      )}
+    <ScreenContent>
+      <FlatList
+        // eslint-disable-next-line react-native/no-inline-styles
+        contentContainerStyle={{ gap: 12 }}
+        data={tickets}
+        renderItem={renderItem}
+      />
     </ScreenContent>
   )
 }
 
 const HistoryRoute = () => {
   const { data: ticketsResponse } = useQueryWithFocusRefetch(ticketsOptions({ active: false }))
+
   const renderItem: ListRenderItem<TicketDto> = useCallback(
     ({ item }) => <TicketCard ticket={item} />,
     [],
@@ -92,8 +82,8 @@ const Page = () => {
 
   const [index, setIndex] = useState(0)
   const [routes] = useState([
-    { key: 'active', title: 'Active tickets' },
-    { key: 'history', title: 'History' },
+    { key: 'active', title: t('activeTickets') },
+    { key: 'history', title: t('history') },
   ])
 
   return (

--- a/app/zone-details/index.tsx
+++ b/app/zone-details/index.tsx
@@ -17,20 +17,21 @@ export type ZoneDetailsParamas = {
 }
 
 const ZoneDetailsScreen = () => {
-  // reason for not passing the whole object: https://reactnavigation.org/docs/params/#what-should-be-in-params
-  const zoneDetailsParams = useLocalSearchParams<ZoneDetailsParamas>()
-  const t = useTranslation()
+  const t = useTranslation('ZoneDetailsScreen')
 
-  const zone = useMapZone(zoneDetailsParams.udrId ?? null, true)
+  // reason for not passing the whole object: https://reactnavigation.org/docs/params/#what-should-be-in-params
+  const { udrId } = useLocalSearchParams<ZoneDetailsParamas>()
+
+  const zone = useMapZone(udrId ?? null, true)
 
   if (!zone) {
     return null
   }
 
   return (
-    <ScreenView title={t('ZoneDetailsScreen.title')}>
+    <ScreenView title={t('title')}>
       <ScreenContent>
-        <FlexRow className="py-4">
+        <FlexRow>
           <ZoneBadge label={zone.udrId.toString()} />
           <Typography className="flex-1">{zone.name}</Typography>
           <Typography variant="default-bold">{formatPricePerHour(zone.price)}</Typography>
@@ -38,21 +39,19 @@ const ZoneDetailsScreen = () => {
 
         <Divider />
 
-        <FlexRow className="justify-start py-4">
-          <View
-            className="h-6 w-6 items-center justify-center bg-dark"
-            // eslint-disable-next-line react-native/no-inline-styles
-            style={{ borderRadius: 12 }}
-          >
+        <FlexRow className="justify-start">
+          <View className="h-6 w-6 items-center justify-center rounded-full bg-dark">
             <Icon name="local-parking" size={12} className="text-white" />
           </View>
           <Typography variant="default-bold">{zone.reservedParking}</Typography>
         </FlexRow>
+
         <Divider />
-        {zone.additionalInformation ? (
-          <FlexRow className="justify-start py-4">
+
+        {zone.paidHours ? (
+          <FlexRow className="justify-start">
             <Typography>{'\u2022'}</Typography>
-            <Typography>{zone.additionalInformation}</Typography>
+            <Typography>{zone.paidHours}</Typography>
           </FlexRow>
         ) : null}
       </ScreenContent>

--- a/components/map/MapZoneBottomSheet.tsx
+++ b/components/map/MapZoneBottomSheet.tsx
@@ -26,8 +26,8 @@ import { GeocodingFeature, NormalizedUdrZone } from '@/modules/map/types'
 import { formatPricePerHour } from '@/utils/formatPricePerHour'
 
 const SNAP_POINTS = {
-  noZone: 220,
-  zone: 320,
+  noZone: 216,
+  zone: 282,
   searchExpanded: '100%',
 }
 
@@ -44,23 +44,27 @@ const MapZoneBottomSheet = forwardRef<BottomSheet, Props>((props, ref) => {
 
   const t = useTranslation()
   const localRef = useRef<BottomSheet>(null)
-  const { top } = useSafeAreaInsets()
+  const { top, bottom } = useSafeAreaInsets()
   const refSetter = useMultipleRefsSetter(ref, localRef)
   const isZoneSelected = Boolean(selectedZone)
   const [isFullHeightEnabled, setIsFullHeightEnabled] = useState(false)
   const inputRef = useRef<TextInput>(null)
 
   const snapPoints = useMemo(() => {
-    const newSnapPoints: (string | number)[] = [SNAP_POINTS.noZone]
+    const newSnapPoints: (string | number)[] = []
+
+    if (!isZoneSelected) {
+      newSnapPoints.push(SNAP_POINTS.noZone + bottom)
+    }
     if (isZoneSelected) {
-      newSnapPoints.push(SNAP_POINTS.zone)
+      newSnapPoints.push(SNAP_POINTS.zone + bottom)
     }
     if (isFullHeightEnabled) {
       newSnapPoints.push(SNAP_POINTS.searchExpanded)
     }
 
     return newSnapPoints
-  }, [isZoneSelected, isFullHeightEnabled])
+  }, [isZoneSelected, isFullHeightEnabled, bottom])
 
   useEffect(() => {
     if (snapPoints.at(-1) === SNAP_POINTS.searchExpanded) {

--- a/components/screen-layout/EmptyStateScreen.tsx
+++ b/components/screen-layout/EmptyStateScreen.tsx
@@ -5,20 +5,29 @@ import ContentWithAvatar from '@/components/screen-layout/ContentWithAvatar'
 import ScreenViewCentered from '@/components/screen-layout/ScreenViewCentered'
 
 type Props = {
-  title: string
+  contentTitle: string
   text?: string
-  button?: ReactNode
-  buttonPosition?: 'insideContent' | 'bottom'
+  actionButton?: ReactNode
+  actionButtonPosition?: 'insideContent' | 'bottom'
 }
 
-const EmptyStateScreen = ({ title, text, button, buttonPosition = 'bottom' }: Props) => {
+const EmptyStateScreen = ({
+  contentTitle,
+  text,
+  actionButton,
+  actionButtonPosition = 'bottom',
+}: Props) => {
   return (
-    <ScreenViewCentered actionButton={buttonPosition === 'bottom' && button ? button : undefined}>
+    <ScreenViewCentered
+      actionButton={actionButtonPosition === 'bottom' && actionButton ? actionButton : undefined}
+    >
       <ContentWithAvatar
-        title={title}
+        title={contentTitle}
         text={text}
         customAvatarComponent={<EmptyStateAvatar />}
-        actionButton={buttonPosition === 'insideContent' && button ? button : undefined}
+        actionButton={
+          actionButtonPosition === 'insideContent' && actionButton ? actionButton : undefined
+        }
       />
     </ScreenViewCentered>
   )

--- a/components/screen-layout/ScreenView.tsx
+++ b/components/screen-layout/ScreenView.tsx
@@ -35,7 +35,7 @@ const ScreenView = ({
 
   return (
     <View className={clsx('flex-1 bg-white', className)} {...rest}>
-      <Stack.Screen options={{ title }} />
+      {title?.length ? <Stack.Screen options={{ title }} /> : null}
 
       {backgroundVariant === 'dots' && (
         <Image source={dottedBackground} className="absolute h-full w-full" />

--- a/modules/backend/openapi-generated/api.ts
+++ b/modules/backend/openapi-generated/api.ts
@@ -484,6 +484,31 @@ export interface MobileDeviceResponseDto {
 /**
  *
  * @export
+ * @enum {string}
+ */
+
+export const PRICINGAPIERROR = {
+  InvalidParkingStart: 'InvalidParkingStart',
+  InvalidParkingEnd: 'InvalidParkingEnd',
+  InvalidParkingTime: 'InvalidParkingTime',
+  TooLongParkingTime: 'TooLongParkingTime',
+  TooShortParkingTime: 'TooShortParkingTime',
+  FreeTicket: 'FreeTicket',
+  InsufficientCredit: 'InsufficientCredit',
+  NoUsableParkingCardFound: 'NoUsableParkingCardFound',
+  PermitCardActive: 'PermitCardActive',
+  TicketAlreadyExists: 'TicketAlreadyExists',
+  BadDateFormat: 'BadDateFormat',
+  CardNotValid: 'CardNotValid',
+  TicketAlreadyShortened: 'TicketAlreadyShortened',
+  BadRequest: 'BadRequest',
+} as const
+
+export type PRICINGAPIERROR = (typeof PRICINGAPIERROR)[keyof typeof PRICINGAPIERROR]
+
+/**
+ *
+ * @export
  * @interface PaginationInfo
  */
 export interface PaginationInfo {
@@ -687,6 +712,7 @@ export const SERVICEERROR = {
   PaymentInit: 'PAYMENT_INIT',
   PaymentValdation: 'PAYMENT_VALDATION',
   EmailVerificationTokenIncorrect: 'EMAIL_VERIFICATION_TOKEN_INCORRECT',
+  EmailVerificationTokenExpired: 'EMAIL_VERIFICATION_TOKEN_EXPIRED',
   EmailAlreadyVerified: 'EMAIL_ALREADY_VERIFIED',
   TicketProlongationNonActive: 'TICKET_PROLONGATION_NON_ACTIVE',
   TicketMissingParkdotsId: 'TICKET_MISSING_PARKDOTS_ID',
@@ -828,6 +854,38 @@ export interface ServiceErrorDto {
    * @memberof ServiceErrorDto
    */
   errorName: SERVICEERROR
+}
+
+/**
+ *
+ * @export
+ * @interface ServicePricingErrorDto
+ */
+export interface ServicePricingErrorDto {
+  /**
+   * Status in text
+   * @type {string}
+   * @memberof ServicePricingErrorDto
+   */
+  status: string
+  /**
+   * Detail error message
+   * @type {string}
+   * @memberof ServicePricingErrorDto
+   */
+  message: string
+  /**
+   * Status Code
+   * @type {number}
+   * @memberof ServicePricingErrorDto
+   */
+  statusCode: number
+  /**
+   *
+   * @type {PRICINGAPIERROR}
+   * @memberof ServicePricingErrorDto
+   */
+  errorName: PRICINGAPIERROR
 }
 
 /**
@@ -1074,6 +1132,38 @@ export interface TicketInitDto {
    * @memberof TicketInitDto
    */
   paymentUrls?: PaymentUrls
+}
+
+/**
+ *
+ * @export
+ * @interface TicketsControllerGetTicketPrice422Response
+ */
+export interface TicketsControllerGetTicketPrice422Response {
+  /**
+   * Status in text
+   * @type {string}
+   * @memberof TicketsControllerGetTicketPrice422Response
+   */
+  status: string
+  /**
+   * Detail error message
+   * @type {string}
+   * @memberof TicketsControllerGetTicketPrice422Response
+   */
+  message: string
+  /**
+   * Status Code
+   * @type {number}
+   * @memberof TicketsControllerGetTicketPrice422Response
+   */
+  statusCode: number
+  /**
+   *
+   * @type {PRICINGAPIERROR}
+   * @memberof TicketsControllerGetTicketPrice422Response
+   */
+  errorName: PRICINGAPIERROR
 }
 
 /**

--- a/translations/en.json
+++ b/translations/en.json
@@ -113,7 +113,12 @@
     "validUntil": "Valid until"
   },
   "Tickets": {
-    "title": "Parking tickets"
+    "title": "Parking tickets",
+    "activeTickets": "Active tickets",
+    "history": "History",
+    "noActiveTickets": "No active tickets",
+    "noActiveTicketsText": "After you buy your parking ticket it will show here.",
+    "buyTicket": "Buy ticket"
   },
   "TicketCard": {
     "prolong": "Prolong",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -113,7 +113,12 @@
     "validUntil": "Platná do"
   },
   "Tickets": {
-    "title": "Parkovacie lístky"
+    "title": "Parkovacie lístky",
+    "activeTickets": "Aktívne lístky",
+    "history": "História",
+    "noActiveTickets": "Žiadne aktívne lístky",
+    "noActiveTicketsText": "Po zakúpení parkovacieho lístka sa lístok zobrazí v tejto sekcii.",
+    "buyTicket": "Kúpiť lístok"
   },
   "TicketCard": {
     "prolong": "Predĺžiť",


### PR DESCRIPTION
- conditionally render `<Stack.Screen>` only if `title` is provided - this allows us to use `EmptyStateScreen` inside `ScreenView` without overriding title
- few minor changes in `EmptyStateScreen`
- add some translations for Tickets screen
- update api