### PR TITLE
Fix: quickfix sizes by setting rem to 16

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,6 +14,7 @@ import { PortalProvider } from '@gorhom/portal'
 import Mapbox from '@rnmapbox/maps'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { SplashScreen, Stack } from 'expo-router'
+import { NativeWindStyleSheet } from 'nativewind'
 import { useEffect, useState } from 'react'
 import { NativeModules } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
@@ -28,6 +29,10 @@ import MapZonesProvider from '@/state/MapZonesProvider/MapZonesProvider'
 import colors from '@/tailwind.config.colors'
 
 SplashScreen.preventAutoHideAsync()
+
+/* Quickfix - https://github.com/marklawlor/nativewind/issues/308
+   see "Base scaling has changed" and "rem Units" sections */
+NativeWindStyleSheet.setVariables({ '--rem': 16 })
 
 const { UIManager } = NativeModules
 

--- a/components/info/AvatarSquare.tsx
+++ b/components/info/AvatarSquare.tsx
@@ -22,7 +22,7 @@ const AvatarSquare = ({ variant }: Props) => {
 
   return (
     <View
-      className={clsx('flex h-[40px] w-[40px] items-center justify-center rounded p-2.5', {
+      className={clsx('flex h-10 w-10 items-center justify-center rounded p-2.5', {
         'bg-dark': variant === 'payment-card',
         'bg-visitorCard': variant === 'visitor-card',
         'bg-black': variant === 'apple-pay',


### PR DESCRIPTION
See  https://github.com/marklawlor/nativewind/issues/308 - "Base scaling has changed" and "rem Units" sections

Predefined and arbitrary values should match now (`h-10` = `h-[40px]`)

We should investigate more, how to do sizing in nativewind, why rem is 14 by default and how to use it together with pixels (some components use pixels instead of rems, e.g. `size` in `<Icon>`)

There is also Nativewind v4 comming soon.