### PR TITLE
Feat/#174 purchase confirmation

### DIFF
--- a/app/(purchase-and-payment)/ticket-purchase.tsx
+++ b/app/(purchase-and-payment)/ticket-purchase.tsx
@@ -1,0 +1,66 @@
+import { Link, useLocalSearchParams } from 'expo-router'
+import React from 'react'
+
+import ContinueButton from '@/components/navigation/ContinueButton'
+import ContentWithAvatar from '@/components/screen-layout/ContentWithAvatar'
+import ScreenViewCentered from '@/components/screen-layout/ScreenViewCentered'
+import Panel from '@/components/shared/Panel'
+import Typography from '@/components/shared/Typography'
+import BoughtTicket from '@/components/tickets/BoughtTicket'
+import { useQueryWithFocusRefetch } from '@/hooks/useQueryWithFocusRefetch'
+import { useTranslation } from '@/hooks/useTranslation'
+import { getTicketOptions } from '@/modules/backend/constants/queryOptions'
+
+export type TicketPurchaseSearchParams = {
+  ticketId: string
+}
+
+/**
+ * This page takes care of redirect from Payment gate. Do not change its path, unless it's changes on BE too.
+ *
+ * @constructor
+ */
+
+// TODO repeat request to BE until the state of ticket is SUCCESS or FAIL
+const TicketPurchasePage = () => {
+  const t = useTranslation('PurchaseScreen')
+  const { ticketId } = useLocalSearchParams<TicketPurchaseSearchParams>()
+  const ticketIdParsed = ticketId ? parseInt(ticketId, 10) : undefined
+
+  const { data, isPending, isError, error } = useQueryWithFocusRefetch(
+    getTicketOptions(ticketIdParsed!),
+  )
+
+  return (
+    <ScreenViewCentered
+      actionButton={
+        <Link asChild href="/">
+          <ContinueButton>{t('backToMap')}</ContinueButton>
+        </Link>
+      }
+    >
+      {isPending ? (
+        // TODO show this content when ticket status is PENDING
+        <ContentWithAvatar title="Ticket is being processed" text={ticketId} />
+      ) : isError ? (
+        // TODO show tis content when ticket status is FAIL
+        <ContentWithAvatar variant="error" title={t('paymentFailed')} text={t('paymentFailedText')}>
+          <Panel className="bg-negative-light">
+            <Typography>{error.message}</Typography>
+          </Panel>
+        </ContentWithAvatar>
+      ) : (
+        // TODO show this content when ticket status is SUCCESS
+        <ContentWithAvatar
+          variant="success"
+          title={t('paymentSuccessful')}
+          text={t('paymentSuccessfulText')}
+        >
+          <BoughtTicket ticket={data} />
+        </ContentWithAvatar>
+      )}
+    </ScreenViewCentered>
+  )
+}
+
+export default TicketPurchasePage

--- a/app/about/index.tsx
+++ b/app/about/index.tsx
@@ -1,0 +1,66 @@
+import { Link } from 'expo-router'
+import React from 'react'
+import { View } from 'react-native'
+
+import { WebviewSearchParams } from '@/app/about/webview'
+import ListRow from '@/components/list-rows/ListRow'
+import ScreenContent from '@/components/screen-layout/ScreenContent'
+import ScreenView from '@/components/screen-layout/ScreenView'
+import Divider from '@/components/shared/Divider'
+import PressableStyled from '@/components/shared/PressableStyled'
+import { useTranslation } from '@/hooks/useTranslation'
+
+const Page = () => {
+  const t = useTranslation('AboutScreen')
+
+  const links = [
+    {
+      label: t('links.termsAndConditions.label'),
+      url: t('links.termsAndConditions.url'),
+      icon: 'language',
+    },
+    {
+      label: t('links.privacyPolicy.label'),
+      url: t('links.privacyPolicy.url'),
+      icon: 'description',
+    },
+    {
+      label: t('links.contactUs.label'),
+      url: t('links.contactUs.url'),
+      icon: 'phone',
+    },
+    {
+      label: t('links.rateTheApp.label'),
+      url: t('links.rateTheApp.url'),
+      icon: 'star',
+    },
+  ] as const
+
+  return (
+    <ScreenView title={t('title')}>
+      <ScreenContent>
+        <View>
+          {links.map((link) => (
+            <>
+              <Link
+                key={link.label}
+                asChild
+                href={{
+                  pathname: `/about/webview`,
+                  params: { webviewUri: encodeURI(link.url) } satisfies WebviewSearchParams,
+                }}
+              >
+                <PressableStyled>
+                  <ListRow label={link.label} icon={link.icon} />
+                </PressableStyled>
+              </Link>
+              <Divider />
+            </>
+          ))}
+        </View>
+      </ScreenContent>
+    </ScreenView>
+  )
+}
+
+export default Page

--- a/app/about/webview.tsx
+++ b/app/about/webview.tsx
@@ -1,0 +1,36 @@
+import { Stack, useLocalSearchParams } from 'expo-router'
+import React from 'react'
+import { WebView } from 'react-native-webview'
+
+import ScreenView from '@/components/screen-layout/ScreenView'
+import Typography from '@/components/shared/Typography'
+
+export type WebviewSearchParams = {
+  webviewUri: string
+}
+
+// TODO handle errors
+const Page = () => {
+  const { webviewUri } = useLocalSearchParams<WebviewSearchParams>()
+
+  if (!webviewUri) {
+    return <Typography>No uri provided.</Typography>
+  }
+
+  const uriDecoded = decodeURI(webviewUri)
+
+  if (!uriDecoded) {
+    return <Typography>Invalid uri provided.</Typography>
+  }
+
+  return (
+    <ScreenView>
+      {/* TODO find a nicer way how to hide header title */}
+      <Stack.Screen options={{ headerTitle: () => <Typography /> }} />
+
+      <WebView source={{ uri: uriDecoded }} className="flex-1" />
+    </ScreenView>
+  )
+}
+
+export default Page

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -97,6 +97,11 @@ const IndexScreen = () => {
       ) : undefined,
     },
     {
+      label: 'About',
+      icon: 'info',
+      path: '/about',
+    },
+    {
       label: 'Purchase DEV',
       icon: 'payment',
       path: '/purchase',

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -7,6 +7,7 @@ import { StyleSheet, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import ActionRow from '@/components/list-rows/ActionRow'
+import MenuRow from '@/components/list-rows/MenuRow'
 import MapScreen from '@/components/map/MapScreen'
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
 import { IconName } from '@/components/shared/Icon'
@@ -171,11 +172,8 @@ const IndexScreen = () => {
                 href={item.path}
                 onPress={() => bottomSheetRef.current?.close()}
               >
-                <PressableStyled className="flex-row items-center">
-                  <View className="flex-1">
-                    <ActionRow startIcon={item.icon} label={item.label} />
-                  </View>
-                  {item.endSlot}
+                <PressableStyled>
+                  <MenuRow startIcon={item.icon} label={item.label} endSlot={item.endSlot} />
                 </PressableStyled>
               </Link>
             ))}

--- a/components/list-rows/ListRow.tsx
+++ b/components/list-rows/ListRow.tsx
@@ -21,7 +21,7 @@ export type ListRowProps = {
  */
 const ListRow = ({ icon, label, labelClassName, ...rest }: ListRowProps) => {
   return (
-    <View className="flex-row gap-3 py-4" {...rest}>
+    <View className="flex-row gap-4 py-4" {...rest}>
       {icon ? <Icon name={icon} /> : null}
 
       <Typography className={clsx('flex-1', labelClassName)}>{label}</Typography>

--- a/components/list-rows/MenuRow.tsx
+++ b/components/list-rows/MenuRow.tsx
@@ -1,0 +1,30 @@
+import clsx from 'clsx'
+import { ReactNode } from 'react'
+import { View, ViewProps } from 'react-native'
+
+import Icon, { IconName } from '@/components/shared/Icon'
+import Typography from '@/components/shared/Typography'
+
+export type MenuRowProps = {
+  startIcon?: IconName
+  endSlot?: ReactNode
+  label: string
+} & ViewProps
+
+// Figma: https://www.figma.com/file/3TppNabuUdnCChkHG9Vft7/paas-mpa?node-id=2677%3A22255&mode=dev
+
+const MenuRow = ({ startIcon, endSlot, label, className, ...rest }: MenuRowProps) => {
+  return (
+    <View className={clsx('flex-row items-center gap-3 py-2', className)} {...rest}>
+      {startIcon && <Icon name={startIcon} size={20} />}
+
+      <Typography variant="default-semibold" className="flex-1">
+        {label}
+      </Typography>
+
+      {endSlot}
+    </View>
+  )
+}
+
+export default MenuRow

--- a/components/tickets/BoughtTicket.tsx
+++ b/components/tickets/BoughtTicket.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+
+import ZoneBadge from '@/components/info/ZoneBadge'
+import Divider from '@/components/shared/Divider'
+import Field from '@/components/shared/Field'
+import FlexRow from '@/components/shared/FlexRow'
+import Panel from '@/components/shared/Panel'
+import Typography from '@/components/shared/Typography'
+import { useLocale, useTranslation } from '@/hooks/useTranslation'
+import { TicketDto } from '@/modules/backend/openapi-generated'
+import { useMapZone } from '@/state/MapZonesProvider/useMapZone'
+import { formatDateTime } from '@/utils/formatDateTime'
+
+type Props = {
+  ticket: TicketDto
+}
+
+const BoughtTicket = ({ ticket }: Props) => {
+  const locale = useLocale()
+  const t = useTranslation('BoughtTicket')
+
+  const zone = useMapZone(ticket.udr, true)
+
+  return (
+    <Field label={t('yourTicket')} labelInsertArea={<ZoneBadge label={ticket.udr} />}>
+      <Panel className="g-4">
+        <FlexRow>
+          <Typography>{zone?.name}</Typography>
+        </FlexRow>
+
+        <Divider />
+
+        <FlexRow>
+          <Typography>{t('licencePlate')}</Typography>
+          <Typography variant="default-bold">{ticket.ecv}</Typography>
+        </FlexRow>
+
+        <Divider />
+
+        <FlexRow>
+          <Typography>{t('validUntil')}</Typography>
+          <Typography variant="default-bold">
+            {formatDateTime(new Date(ticket.parkingEnd), locale)}
+          </Typography>
+        </FlexRow>
+      </Panel>
+    </Field>
+  )
+}
+
+export default BoughtTicket

--- a/components/tickets/TicketCard.tsx
+++ b/components/tickets/TicketCard.tsx
@@ -55,7 +55,7 @@ const TicketCard = ({ ticket }: Props) => {
                 {zone.cityDistrict} – {zone.name}
               </Typography>
             ) : null}
-            <Typography variant="small">Licence plate number</Typography>
+            <Typography variant="small">{ticket.ecv}</Typography>
           </View>
 
           <View className="g-2">

--- a/modules/backend/constants/queryOptions.ts
+++ b/modules/backend/constants/queryOptions.ts
@@ -68,6 +68,14 @@ export const ticketPriceOptions = (
     enabled: !!udr && !!licencePlate && !!duration,
   })
 
+export const getTicketOptions = (ticketId: number) =>
+  queryOptions({
+    queryKey: ['ticket', ticketId],
+    queryFn: () => clientApi.ticketsControllerTicketsGetOne(ticketId),
+    select: (res) => res.data,
+    enabled: !!ticketId,
+  })
+
 export const visitorCardsOptions = () =>
   queryOptions({
     queryKey: ['VisitorCards'],

--- a/modules/backend/openapi-generated/api.ts
+++ b/modules/backend/openapi-generated/api.ts
@@ -927,6 +927,12 @@ export interface SystemErrorDto {
  */
 export interface TicketDto {
   /**
+   * Database id of the vehicle
+   * @type {number}
+   * @memberof TicketDto
+   */
+  id: number
+  /**
    * Unique identification of parking slot (specific section of parking regulation)
    * @type {string}
    * @memberof TicketDto
@@ -1030,6 +1036,12 @@ export interface TicketDto {
  * @interface TicketInitDto
  */
 export interface TicketInitDto {
+  /**
+   * Database id of the vehicle
+   * @type {number}
+   * @memberof TicketInitDto
+   */
+  id: number
   /**
    * Unique identification of parking slot (specific section of parking regulation)
    * @type {string}
@@ -1805,6 +1817,40 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         options: localVarRequestOptions,
       }
     },
+    /**
+     * Get information about the status of the parking system.
+     * @summary Healthcheck for parking system
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    appControllerHealthParkingSystem: async (
+      options: AxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/healthcheck/parking-sytem`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
   }
 }
 
@@ -1825,6 +1871,20 @@ export const DefaultApiFp = function (configuration?: Configuration) {
       options?: AxiosRequestConfig,
     ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.appControllerHealth(options)
+      return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)
+    },
+    /**
+     * Get information about the status of the parking system.
+     * @summary Healthcheck for parking system
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async appControllerHealthParkingSystem(
+      options?: AxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.appControllerHealthParkingSystem(
+        options,
+      )
       return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)
     },
   }
@@ -1850,6 +1910,17 @@ export const DefaultApiFactory = function (
     appControllerHealth(options?: AxiosRequestConfig): AxiosPromise<void> {
       return localVarFp.appControllerHealth(options).then((request) => request(axios, basePath))
     },
+    /**
+     * Get information about the status of the parking system.
+     * @summary Healthcheck for parking system
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    appControllerHealthParkingSystem(options?: AxiosRequestConfig): AxiosPromise<void> {
+      return localVarFp
+        .appControllerHealthParkingSystem(options)
+        .then((request) => request(axios, basePath))
+    },
   }
 }
 
@@ -1870,6 +1941,19 @@ export class DefaultApi extends BaseAPI {
   public appControllerHealth(options?: AxiosRequestConfig) {
     return DefaultApiFp(this.configuration)
       .appControllerHealth(options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   * Get information about the status of the parking system.
+   * @summary Healthcheck for parking system
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof DefaultApi
+   */
+  public appControllerHealthParkingSystem(options?: AxiosRequestConfig) {
+    return DefaultApiFp(this.configuration)
+      .appControllerHealthParkingSystem(options)
       .then((request) => request(this.axios, this.basePath))
   }
 }
@@ -2602,6 +2686,51 @@ export const TicketsApiAxiosParamCreator = function (configuration?: Configurati
   return {
     /**
      *
+     * @summary WIP: Get URL to ticket receipt
+     * @param {number} id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    ticketsControllerGetReceipt: async (
+      id: number,
+      options: AxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists('ticketsControllerGetReceipt', 'id', id)
+      const localVarPath = `/tickets/receipt/{id}`.replace(
+        `{${'id'}}`,
+        encodeURIComponent(String(id)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication cognito required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     *
      * @summary Get ticket price
      * @param {GetTicketPriceRequestDto} getTicketPriceRequestDto
      * @param {*} [options] Override http request option.
@@ -3122,6 +3251,48 @@ export const TicketsApiAxiosParamCreator = function (configuration?: Configurati
         options: localVarRequestOptions,
       }
     },
+    /**
+     *
+     * @summary Get single ticket
+     * @param {number} id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    ticketsControllerTicketsGetOne: async (
+      id: number,
+      options: AxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists('ticketsControllerTicketsGetOne', 'id', id)
+      const localVarPath = `/tickets/{id}`.replace(`{${'id'}}`, encodeURIComponent(String(id)))
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication cognito required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
   }
 }
 
@@ -3132,6 +3303,23 @@ export const TicketsApiAxiosParamCreator = function (configuration?: Configurati
 export const TicketsApiFp = function (configuration?: Configuration) {
   const localVarAxiosParamCreator = TicketsApiAxiosParamCreator(configuration)
   return {
+    /**
+     *
+     * @summary WIP: Get URL to ticket receipt
+     * @param {number} id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async ticketsControllerGetReceipt(
+      id: number,
+      options?: AxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.ticketsControllerGetReceipt(
+        id,
+        options,
+      )
+      return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)
+    },
     /**
      *
      * @summary Get ticket price
@@ -3328,6 +3516,23 @@ export const TicketsApiFp = function (configuration?: Configuration) {
       )
       return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)
     },
+    /**
+     *
+     * @summary Get single ticket
+     * @param {number} id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async ticketsControllerTicketsGetOne(
+      id: number,
+      options?: AxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TicketDto>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.ticketsControllerTicketsGetOne(
+        id,
+        options,
+      )
+      return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)
+    },
   }
 }
 
@@ -3342,6 +3547,18 @@ export const TicketsApiFactory = function (
 ) {
   const localVarFp = TicketsApiFp(configuration)
   return {
+    /**
+     *
+     * @summary WIP: Get URL to ticket receipt
+     * @param {number} id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    ticketsControllerGetReceipt(id: number, options?: AxiosRequestConfig): AxiosPromise<string> {
+      return localVarFp
+        .ticketsControllerGetReceipt(id, options)
+        .then((request) => request(axios, basePath))
+    },
     /**
      *
      * @summary Get ticket price
@@ -3516,6 +3733,21 @@ export const TicketsApiFactory = function (
         .ticketsControllerTicketsGetMany(active, page, pageSize, ecv, options)
         .then((request) => request(axios, basePath))
     },
+    /**
+     *
+     * @summary Get single ticket
+     * @param {number} id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    ticketsControllerTicketsGetOne(
+      id: number,
+      options?: AxiosRequestConfig,
+    ): AxiosPromise<TicketDto> {
+      return localVarFp
+        .ticketsControllerTicketsGetOne(id, options)
+        .then((request) => request(axios, basePath))
+    },
   }
 }
 
@@ -3526,6 +3758,20 @@ export const TicketsApiFactory = function (
  * @extends {BaseAPI}
  */
 export class TicketsApi extends BaseAPI {
+  /**
+   *
+   * @summary WIP: Get URL to ticket receipt
+   * @param {number} id
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TicketsApi
+   */
+  public ticketsControllerGetReceipt(id: number, options?: AxiosRequestConfig) {
+    return TicketsApiFp(this.configuration)
+      .ticketsControllerGetReceipt(id, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
   /**
    *
    * @summary Get ticket price
@@ -3710,6 +3956,20 @@ export class TicketsApi extends BaseAPI {
   ) {
     return TicketsApiFp(this.configuration)
       .ticketsControllerTicketsGetMany(active, page, pageSize, ecv, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   *
+   * @summary Get single ticket
+   * @param {number} id
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TicketsApi
+   */
+  public ticketsControllerTicketsGetOne(id: number, options?: AxiosRequestConfig) {
+    return TicketsApiFp(this.configuration)
+      .ticketsControllerTicketsGetOne(id, options)
       .then((request) => request(this.axios, this.basePath))
   }
 }
@@ -4428,64 +4688,6 @@ export const VerifiedEmailsApiAxiosParamCreator = function (configuration?: Conf
     },
     /**
      *
-     * @summary Get the target URL to route the user for email verification
-     * @param {string} userAgent
-     * @param {string} token
-     * @param {string} key
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    verifiedEmailsControllerGetVerificationUrl: async (
-      userAgent: string,
-      token: string,
-      key: string,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'userAgent' is not null or undefined
-      assertParamExists('verifiedEmailsControllerGetVerificationUrl', 'userAgent', userAgent)
-      // verify required parameter 'token' is not null or undefined
-      assertParamExists('verifiedEmailsControllerGetVerificationUrl', 'token', token)
-      // verify required parameter 'key' is not null or undefined
-      assertParamExists('verifiedEmailsControllerGetVerificationUrl', 'key', key)
-      const localVarPath = `/verified-emails/verification-target`
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      if (token !== undefined) {
-        localVarQueryParameter['token'] = token
-      }
-
-      if (key !== undefined) {
-        localVarQueryParameter['key'] = key
-      }
-
-      if (userAgent != null) {
-        localVarHeaderParameter['user-agent'] = String(userAgent)
-      }
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
-     *
      * @summary Refreshes all parking cards for the email
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -4698,30 +4900,6 @@ export const VerifiedEmailsApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @summary Get the target URL to route the user for email verification
-     * @param {string} userAgent
-     * @param {string} token
-     * @param {string} key
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async verifiedEmailsControllerGetVerificationUrl(
-      userAgent: string,
-      token: string,
-      key: string,
-      options?: AxiosRequestConfig,
-    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.verifiedEmailsControllerGetVerificationUrl(
-          userAgent,
-          token,
-          key,
-          options,
-        )
-      return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)
-    },
-    /**
-     *
      * @summary Refreshes all parking cards for the email
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -4824,25 +5002,6 @@ export const VerifiedEmailsApiFactory = function (
     },
     /**
      *
-     * @summary Get the target URL to route the user for email verification
-     * @param {string} userAgent
-     * @param {string} token
-     * @param {string} key
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    verifiedEmailsControllerGetVerificationUrl(
-      userAgent: string,
-      token: string,
-      key: string,
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<void> {
-      return localVarFp
-        .verifiedEmailsControllerGetVerificationUrl(userAgent, token, key, options)
-        .then((request) => request(axios, basePath))
-    },
-    /**
-     *
      * @summary Refreshes all parking cards for the email
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -4922,27 +5081,6 @@ export class VerifiedEmailsApi extends BaseAPI {
   public verifiedEmailsControllerDeleteVerifiedEmail(id: number, options?: AxiosRequestConfig) {
     return VerifiedEmailsApiFp(this.configuration)
       .verifiedEmailsControllerDeleteVerifiedEmail(id, options)
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
-   *
-   * @summary Get the target URL to route the user for email verification
-   * @param {string} userAgent
-   * @param {string} token
-   * @param {string} key
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof VerifiedEmailsApi
-   */
-  public verifiedEmailsControllerGetVerificationUrl(
-    userAgent: string,
-    token: string,
-    key: string,
-    options?: AxiosRequestConfig,
-  ) {
-    return VerifiedEmailsApiFp(this.configuration)
-      .verifiedEmailsControllerGetVerificationUrl(userAgent, token, key, options)
       .then((request) => request(this.axios, this.basePath))
   }
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -272,5 +272,26 @@
     "title": "Announcements",
     "noAnnouncementsTitle": "No announcements",
     "learnMore": "Learn more"
+  },
+  "AboutScreen": {
+    "title": "About",
+    "links": {
+      "termsAndConditions": {
+        "label": "Terms & conditions",
+        "url": "https://paas.sk/ochrana-osobnych-udajov/"
+      },
+      "privacyPolicy": {
+        "label": "Privacy policy",
+        "url": "https://paas.sk/ochrana-osobnych-udajov/"
+      },
+      "contactUs": {
+        "label": "Contact us",
+        "url": "https://paas.sk/kontakt/"
+      },
+      "rateTheApp": {
+        "label": "Rate the app",
+        "url": "https://paas.sk/ochrana-osobnych-udajov/"
+      }
+    }
   }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -35,7 +35,17 @@
     "customParkingTimeTitle": "Custom time",
     "chooseVehicleFieldLabel": "Choose vehicle",
     "customParkingTimeFieldLabel": "Choose time",
-    "chooseParkingZoneEmptyControlLabel": "Choose parking zone"
+    "chooseParkingZoneEmptyControlLabel": "Choose parking zone",
+    "backToMap": "Back to map",
+    "paymentFailed": "Payment failed",
+    "paymentFailedText": "Your payment has failed. \nPlease try again.",
+    "paymentSuccessful": "Payment successful",
+    "paymentSuccessfulText": "Your payment ticket has been paid."
+  },
+  "BoughtTicket": {
+    "yourTicket": "Your ticket",
+    "licencePlate": "Car plate number",
+    "validUntil": "Valid to"
   },
   "PurchaseBottomSheet": {
     "pay": "Pay",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -251,5 +251,26 @@
     "title": "Oznámenia",
     "noAnnouncementsTitle": "Žiadne oznámenia",
     "learnMore": "Viac informácií"
+  },
+  "AboutScreen": {
+    "title": "O nás",
+    "links": {
+      "termsAndConditions": {
+        "label": "Všeobecné obchodné podmienky",
+        "url": "https://paas.sk/ochrana-osobnych-udajov/"
+      },
+      "privacyPolicy": {
+        "label": "Ochrana osobných údajov",
+        "url": "https://paas.sk/ochrana-osobnych-udajov/"
+      },
+      "contactUs": {
+        "label": "Kontakty",
+        "url": "https://paas.sk/kontakt/"
+      },
+      "rateTheApp": {
+        "label": "Ohodnoďte nás",
+        "url": "https://paas.sk/ochrana-osobnych-udajov/"
+      }
+    }
   }
 }

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -35,7 +35,17 @@
     "customParkingTimeTitle": "Vlastný čas",
     "chooseVehicleFieldLabel": "Vyberte vozidlo",
     "customParkingTimeFieldLabel": "Vyberte čas",
-    "chooseParkingZoneEmptyControlLabel": "Vyberte úsek parkovania"
+    "chooseParkingZoneEmptyControlLabel": "Vyberte úsek parkovania",
+    "backToMap": "Späť na mapu",
+    "paymentFailed": "Platba zlyhala",
+    "paymentFailedText": "Mrzí nás to, vaša platba zlyhala.\nProsím, skúste to znova.",
+    "paymentSuccessful": "Úspešná platba",
+    "paymentSuccessfulText": "Ďakujeme, váš parkovací lístok bol uhradený."
+  },
+  "BoughtTicket": {
+    "yourTicket": "Parkovací lístok",
+    "licencePlate": "Evidenčné číslo",
+    "validUntil": "Platnosť do"
   },
   "PurchaseBottomSheet": {
     "pay": "Zaplatiť",


### PR DESCRIPTION
- add `ticket-purchase` screen, that handles redirects from payment-gate
- the screen requests status of the new ticket

TODO
- status request should be repeated until it gets SUCCESS or FAIL ticket status