### PR TITLE
change app version to 1.0.3

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -3,7 +3,7 @@ module.exports = {
     name: 'PAAS',
     slug: 'paas',
     scheme: 'paasmpa',
-    version: '1.0.2-alpha.0',
+    version: '1.0.3',
     orientation: 'portrait',
     icon: './assets/icon.png',
     userInterfaceStyle: 'light',


### PR DESCRIPTION
Only simple versioning is supported:
"CFBundleShortVersionString (version field in app.json/app.config.js) must be a period-separated list of three non-negative integers. Current value: 1.0.2-alpha.0"
