### PR TITLE
fix #117: Skip payment gate when not needed

### DIFF
--- a/app/(app)/(purchase-and-payment)/purchase/index.tsx
+++ b/app/(app)/(purchase-and-payment)/purchase/index.tsx
@@ -1,16 +1,22 @@
 import BottomSheet from '@gorhom/bottom-sheet'
-import { isAxiosError } from 'axios'
-import { Link } from 'expo-router'
+import { useMutation } from '@tanstack/react-query'
+import { Link, router } from 'expo-router'
 import { useEffect, useRef, useState } from 'react'
-import { ScrollView } from 'react-native'
+import { ScrollView, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
+import { PaymentSearchParams } from '@/app/(app)/(purchase-and-payment)/purchase/payment'
+import { TicketPurchaseSearchParams } from '@/app/(app)/(purchase-and-payment)/ticket-purchase'
 import TimeSelector from '@/components/controls/date-time/TimeSelector'
 import ParkingZoneField from '@/components/controls/ParkingZoneField'
 import PaymentMethodsFieldControl from '@/components/controls/payment-methods/PaymentMethodsFieldControl'
 import BonusCardRow from '@/components/controls/payment-methods/rows/BonusCardRow'
 import VehicleFieldControl from '@/components/controls/vehicles/VehicleFieldControl'
+import PurchaseErrorPanel from '@/components/purchase/PurchaseErrorPanel'
+import PurchaseSummaryRow from '@/components/purchase/PurchaseSummaryRow'
 import ScreenContent from '@/components/screen-layout/ScreenContent'
 import ScreenView from '@/components/screen-layout/ScreenView'
+import Button from '@/components/shared/Button'
 import Field from '@/components/shared/Field'
 import PressableStyled from '@/components/shared/PressableStyled'
 import PurchaseBottomSheet from '@/components/tickets/PurchaseBottomSheet'
@@ -18,19 +24,19 @@ import { useDefaultPaymentOption } from '@/hooks/useDefaultPaymentOption'
 import { useQueryWithFocusRefetch } from '@/hooks/useQueryWithFocusRefetch'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useVehicles } from '@/hooks/useVehicles'
+import { clientApi } from '@/modules/backend/client-api'
 import { ticketPriceOptions } from '@/modules/backend/constants/queryOptions'
-import { GetTicketPriceRequestDto } from '@/modules/backend/openapi-generated'
+import {
+  GetTicketPriceRequestDto,
+  InitiatePaymentRequestDto,
+} from '@/modules/backend/openapi-generated'
 import { usePurchaseStoreContext } from '@/state/PurchaseStoreProvider/usePurchaseStoreContext'
 import { usePurchaseStoreUpdateContext } from '@/state/PurchaseStoreProvider/usePurchaseStoreUpdateContext'
 
-export type PurchaseSearchParams = {
-  udrId?: string
-}
-
 const PurchaseScreen = () => {
   const t = useTranslation('PurchaseScreen')
+  const insets = useSafeAreaInsets()
   const bottomSheetRef = useRef<BottomSheet>(null)
-  // height of the button + safeArea bottom inset
   // TODO: find solution for height of bottom content with drawing
   const [purchaseButtonContainerHeight, setPurchaseButtonContainerHeight] = useState(0)
 
@@ -43,7 +49,7 @@ const PurchaseScreen = () => {
   const dateNow = Date.now()
   const parkingStart = new Date(dateNow).toISOString()
   const parkingEnd = new Date(dateNow + duration * 1000).toISOString()
-  const body: GetTicketPriceRequestDto = {
+  const priceRequestBody: GetTicketPriceRequestDto = {
     npkId: npk?.identificator || undefined,
     ticket: {
       udr: String(udr?.udrId) ?? '',
@@ -54,7 +60,7 @@ const PurchaseScreen = () => {
     },
   }
 
-  // Set licencePlate to defaultVehicle if empty
+  /** Set licencePlate to defaultVehicle if empty */
   useEffect(() => {
     if (!(licencePlate && getVehicle(licencePlate)) && defaultVehicle) {
       onPurchaseStoreUpdate({ licencePlate: defaultVehicle.licencePlate })
@@ -62,16 +68,46 @@ const PurchaseScreen = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultVehicle])
 
-  // TODO handleError
-  const { data, isError, error, isFetching } = useQueryWithFocusRefetch(
-    ticketPriceOptions(body, { udr, npk, licencePlate, duration }),
+  const priceQuery = useQueryWithFocusRefetch(
+    ticketPriceOptions(priceRequestBody, { udr, npk, licencePlate, duration }),
   )
 
-  // console.log('body', body)
-  console.log('data', data, isError, error, isAxiosError(error) && error.response?.data)
-
-  const onSelectTime = (value: number) => {
+  const handleSelectTime = (value: number) => {
     onPurchaseStoreUpdate({ duration: value })
+  }
+
+  const initPaymentMutation = useMutation({
+    mutationFn: (bodyInner: InitiatePaymentRequestDto) =>
+      clientApi.ticketsControllerInitiateTicketPayment(bodyInner),
+  })
+
+  const handlePressPay = () => {
+    initPaymentMutation.mutate(priceRequestBody, {
+      onSuccess: ({ data: ticketInit }) => {
+        /** Redirect to payment gate */
+        if (ticketInit.paymentUrls) {
+          const paymentUrl =
+            paymentOption === 'apple-pay'
+              ? ticketInit.paymentUrls.paymentUrlAPAY
+              : paymentOption === 'google-pay'
+              ? ticketInit.paymentUrls.paymentUrlGPAY
+              : ticketInit.paymentUrls.paymentUrlCard
+
+          router.push({
+            pathname: '/purchase/payment',
+            params: {
+              paymentUrl,
+            } satisfies PaymentSearchParams,
+          })
+          /** Handle payment without payment gate (NPK, BPK with 0€ ticket) */
+        } else {
+          router.push({
+            pathname: '/ticket-purchase',
+            params: { ticketId: ticketInit.id.toString() } satisfies TicketPurchaseSearchParams,
+          })
+        }
+      },
+    })
   }
 
   return (
@@ -91,11 +127,11 @@ const PurchaseScreen = () => {
             </Field>
 
             <Field label={t('parkingTimeFieldLabel')}>
-              <TimeSelector value={duration} onValueChange={onSelectTime} />
+              <TimeSelector value={duration} onValueChange={handleSelectTime} />
             </Field>
 
             <Field label={t('paymentMethodsFieldLabel')}>
-              {data?.creditBpkUsedSeconds ? (
+              {priceQuery.data?.creditBpkUsedSeconds ? (
                 // TODO props
                 <BonusCardRow balance="balance" validUntil="validUntil" />
               ) : null}
@@ -115,13 +151,29 @@ const PurchaseScreen = () => {
 
       <PurchaseBottomSheet
         ref={bottomSheetRef}
-        priceData={data}
-        error={isAxiosError(error) && error.response?.data}
-        isLoading={isFetching}
-        priceRequestBody={body}
-        setPurchaseButtonContainerHeight={setPurchaseButtonContainerHeight}
+        priceData={priceQuery.data}
         purchaseButtonContainerHeight={purchaseButtonContainerHeight}
       />
+
+      <View
+        style={{ paddingBottom: insets.bottom }}
+        className="bg-white px-5 g-3"
+        onLayout={(event) => {
+          setPurchaseButtonContainerHeight(event.nativeEvent.layout.height)
+        }}
+      >
+        <PurchaseSummaryRow priceData={priceQuery.data} />
+
+        <PurchaseErrorPanel priceQuery={priceQuery} />
+
+        <Button
+          onPress={handlePressPay}
+          disabled={!priceQuery.data}
+          loading={priceQuery.isFetching}
+        >
+          {t('pay')}
+        </Button>
+      </View>
     </>
   )
 }

--- a/app/(app)/(purchase-and-payment)/purchase/payment.tsx
+++ b/app/(app)/(purchase-and-payment)/purchase/payment.tsx
@@ -6,7 +6,7 @@ import ScreenView from '@/components/screen-layout/ScreenView'
 import Typography from '@/components/shared/Typography'
 import { useTranslation } from '@/hooks/useTranslation'
 
-type PaymentSearchParams = {
+export type PaymentSearchParams = {
   paymentUrl: string
 }
 

--- a/components/controls/date-time/TimeSelector.tsx
+++ b/components/controls/date-time/TimeSelector.tsx
@@ -13,11 +13,16 @@ import { useLocale, useTranslation } from '@/hooks/useTranslation'
 import { formatDateTime } from '@/utils/formatDateTime'
 import { formatDuration } from '@/utils/formatDuration'
 
+/**
+ * Returns duration in seconds.
+ *
+ * @param date
+ */
 const getDuration = (date: Date) => {
   const now = new Date()
   const diff = date.getTime() - now.getTime()
 
-  return Math.ceil(diff / 1000 / 60)
+  return Math.ceil(diff / 1000)
 }
 
 type Props = {
@@ -78,6 +83,7 @@ const TimeSelector = ({ value, onValueChange }: Props) => {
 
   const handleDatePickerConfirm = (date: Date) => {
     const duration = getDuration(date)
+    console.log('confirm', date, duration)
     onValueChange(duration)
   }
 

--- a/components/purchase/PurchaseErrorPanel.tsx
+++ b/components/purchase/PurchaseErrorPanel.tsx
@@ -15,12 +15,10 @@ type Props = {
 const PurchaseErrorPanel = ({ priceQuery }: Props) => {
   const t = useTranslation('PurchaseScreen')
 
-  // TODO simplify?
   return !priceQuery.data &&
     priceQuery.isError &&
     isAxiosError(priceQuery.error) &&
-    priceQuery.error.response &&
-    priceQuery.error.response.status === 422 &&
+    priceQuery.error.response?.status === 422 &&
     isPricingApiError(priceQuery.error.response.data) ? (
     <Panel className="bg-negative-light px-5 py-4">
       <Typography>{t(`Errors.${priceQuery.error.response.data.errorName}`)}</Typography>

--- a/components/purchase/PurchaseErrorPanel.tsx
+++ b/components/purchase/PurchaseErrorPanel.tsx
@@ -1,0 +1,31 @@
+import { UseQueryResult } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
+import React from 'react'
+
+import Panel from '@/components/shared/Panel'
+import Typography from '@/components/shared/Typography'
+import { useTranslation } from '@/hooks/useTranslation'
+import { GetTicketPriceResponseDto } from '@/modules/backend/openapi-generated'
+import { isPricingApiError } from '@/utils/errorPricingApi'
+
+type Props = {
+  priceQuery: UseQueryResult<GetTicketPriceResponseDto, Error>
+}
+
+const PurchaseErrorPanel = ({ priceQuery }: Props) => {
+  const t = useTranslation('PurchaseScreen')
+
+  // TODO simplify?
+  return !priceQuery.data &&
+    priceQuery.isError &&
+    isAxiosError(priceQuery.error) &&
+    priceQuery.error.response &&
+    priceQuery.error.response.status === 422 &&
+    isPricingApiError(priceQuery.error.response.data) ? (
+    <Panel className="bg-negative-light px-5 py-4">
+      <Typography>{t(`Errors.${priceQuery.error.response.data.errorName}`)}</Typography>
+    </Panel>
+  ) : null
+}
+
+export default PurchaseErrorPanel

--- a/components/purchase/PurchaseSummaryRow.tsx
+++ b/components/purchase/PurchaseSummaryRow.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import FlexRow from '@/components/shared/FlexRow'
+import Typography from '@/components/shared/Typography'
+import { useTranslation } from '@/hooks/useTranslation'
+import { GetTicketPriceResponseDto } from '@/modules/backend/openapi-generated'
+import { formatPrice } from '@/utils/formatPrice'
+
+type Props = {
+  priceData: GetTicketPriceResponseDto | undefined
+}
+
+const PurchaseSummaryRow = ({ priceData }: Props) => {
+  const t = useTranslation('PurchaseScreen')
+
+  /* Toggling visibility instead hiding by "display: none" prevents layout shifts */
+  return (
+    <FlexRow className={priceData ? 'visible' : 'hidden'}>
+      <Typography variant="default-bold">{t('summary')}</Typography>
+      {priceData ? (
+        <Typography variant="default-bold">{formatPrice(priceData.priceTotal)}</Typography>
+      ) : null}
+    </FlexRow>
+  )
+}
+
+export default PurchaseSummaryRow

--- a/components/screen-layout/BottomSheet/BottomSheetHandleWithShadow.tsx
+++ b/components/screen-layout/BottomSheet/BottomSheetHandleWithShadow.tsx
@@ -2,6 +2,8 @@
 import { BottomSheetHandle, BottomSheetHandleProps } from '@gorhom/bottom-sheet'
 import { Shadow } from 'react-native-shadow-2'
 
+export const HANDLE_HEIGHT = 24
+
 const BottomSheetHandleWithShadow = (props: BottomSheetHandleProps) => {
   return (
     <Shadow

--- a/components/tickets/PurchaseBottomSheet.tsx
+++ b/components/tickets/PurchaseBottomSheet.tsx
@@ -15,6 +15,7 @@ import { GetTicketPriceResponseDto } from '@/modules/backend/openapi-generated'
 import { usePurchaseStoreContext } from '@/state/PurchaseStoreProvider/usePurchaseStoreContext'
 import { formatDuration } from '@/utils/formatDuration'
 import { formatPrice } from '@/utils/formatPrice'
+import { isDefined } from '@/utils/isDefined'
 
 type Props = {
   priceData: GetTicketPriceResponseDto | undefined
@@ -88,13 +89,12 @@ const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(
                 </FlexRow>
               ) : null}
 
-              {/* Check if it is present (null/undefined, but show if it is 0) */}
-              {priceData.tax == null ? null : (
+              {isDefined(priceData.tax) ? (
                 <FlexRow>
                   <Typography variant="default">{t('tax')}</Typography>
                   <Typography variant="default-bold">{formatPrice(priceData.tax)}</Typography>
                 </FlexRow>
-              )}
+              ) : null}
 
               <Divider />
             </>

--- a/components/tickets/PurchaseBottomSheet.tsx
+++ b/components/tickets/PurchaseBottomSheet.tsx
@@ -1,200 +1,106 @@
 import BottomSheet from '@gorhom/bottom-sheet'
-import { useMutation } from '@tanstack/react-query'
-import clsx from 'clsx'
-import { router } from 'expo-router'
-import { Dispatch, forwardRef, useMemo } from 'react'
-import { View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { forwardRef, useMemo } from 'react'
 
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
-import BottomSheetHandleWithShadow from '@/components/screen-layout/BottomSheet/BottomSheetHandleWithShadow'
-import Button from '@/components/shared/Button'
+import BottomSheetHandleWithShadow, {
+  HANDLE_HEIGHT,
+} from '@/components/screen-layout/BottomSheet/BottomSheetHandleWithShadow'
 import Divider from '@/components/shared/Divider'
 import FlexRow from '@/components/shared/FlexRow'
 import Panel from '@/components/shared/Panel'
 import Typography from '@/components/shared/Typography'
 import { getDurationFromPriceData } from '@/components/tickets/getDurationFromPriceData'
 import { useTranslation } from '@/hooks/useTranslation'
-import { clientApi } from '@/modules/backend/client-api'
-import {
-  GetTicketPriceRequestDto,
-  GetTicketPriceResponseDto,
-  InitiatePaymentRequestDto,
-} from '@/modules/backend/openapi-generated'
+import { GetTicketPriceResponseDto } from '@/modules/backend/openapi-generated'
 import { usePurchaseStoreContext } from '@/state/PurchaseStoreProvider/usePurchaseStoreContext'
 import { formatDuration } from '@/utils/formatDuration'
 import { formatPrice } from '@/utils/formatPrice'
 
 type Props = {
   priceData: GetTicketPriceResponseDto | undefined
-  isLoading?: boolean
-  priceRequestBody: GetTicketPriceRequestDto
-  error?: { errorName: string }
   purchaseButtonContainerHeight: number
-  setPurchaseButtonContainerHeight: Dispatch<number>
 }
 
 const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(
-  (
-    {
-      priceData,
-      isLoading,
-      error,
-      priceRequestBody,
-      purchaseButtonContainerHeight,
-      setPurchaseButtonContainerHeight,
-    },
-    ref,
-  ) => {
+  ({ priceData, purchaseButtonContainerHeight }, ref) => {
     const t = useTranslation('PurchaseBottomSheet')
     const { udr } = usePurchaseStoreContext()
-    const insets = useSafeAreaInsets()
 
-    const snapPoints = useMemo(() => [24], [])
+    const snapPoints = useMemo(() => [HANDLE_HEIGHT], [])
 
     const durationFromPriceDate = getDurationFromPriceData(priceData)
 
-    const mutation = useMutation({
-      mutationFn: (bodyInner: InitiatePaymentRequestDto) =>
-        clientApi.ticketsControllerInitiateTicketPayment(bodyInner),
-      onMutate: (ctx) => {
-        console.log('onMutate', JSON.stringify(ctx, undefined, 2))
-      },
-    })
-
-    // TODO determine Card/APAY/GPAY
-    const handlePressPay = () => {
-      mutation.mutate(priceRequestBody, {
-        onSuccess: ({ data }) => {
-          console.log(
-            'onSuccess',
-            JSON.stringify(priceRequestBody, undefined, 2),
-            JSON.stringify(data, undefined, 2),
-          )
-          router.push({
-            pathname: '/purchase/payment',
-            params: { paymentUrl: data?.paymentUrls?.paymentUrlCard },
-          })
-        },
-      })
-    }
-
-    // const renderFooter = useCallback(
-    //   (footerProps: BottomSheetFooterProps) => {
-    //     return (
-    //       // eslint-disable-next-line react-native/no-inline-styles
-    //       <BottomSheetFooter style={{ backgroundColor: 'white' }} {...footerProps}>
-    //         <View className="px-5">
-    //           <Link href="/" asChild>
-    //             <Button>{t('pay')}</Button>
-    //           </Link>
-    //         </View>
-    //       </BottomSheetFooter>
-    //     )
-    //   },
-    //   [t],
-    // )
-
     return (
-      <>
-        <BottomSheet
-          ref={ref}
-          enableDynamicSizing
-          // footerComponent={renderFooter}
-          bottomInset={purchaseButtonContainerHeight}
-          snapPoints={snapPoints}
-          handleComponent={BottomSheetHandleWithShadow}
-        >
-          <BottomSheetContent cn="g-3" hideSpacer>
-            {priceData ? (
-              <>
+      <BottomSheet
+        ref={ref}
+        enableDynamicSizing
+        bottomInset={purchaseButtonContainerHeight}
+        snapPoints={snapPoints}
+        handleComponent={BottomSheetHandleWithShadow}
+      >
+        <BottomSheetContent cn="g-3" hideSpacer>
+          {priceData ? (
+            <>
+              <FlexRow>
+                <Typography variant="default">
+                  {t('parkingTime', { time: formatDuration(durationFromPriceDate ?? 0) })}
+                </Typography>
+                <Typography variant="default-bold">
+                  {formatPrice(priceData.priceWithoutDiscount)}
+                </Typography>
+              </FlexRow>
+
+              {/* Is this ever used? */}
+              {udr?.rpkInformation ? (
+                <Panel className="bg-warning-light">
+                  <Typography>{udr.rpkInformation}</Typography>
+                </Panel>
+              ) : null}
+
+              {udr?.npkInformation ? (
+                <Panel className="bg-warning-light">
+                  <Typography>{udr.npkInformation}</Typography>
+                </Panel>
+              ) : null}
+
+              {/* This usually says you cannot use BPK (in 2e zones) */}
+              {udr?.additionalInformation ? (
+                <Panel className="bg-warning-light">
+                  <Typography>{udr.additionalInformation}</Typography>
+                </Panel>
+              ) : null}
+
+              {priceData.creditNpkUsedSeconds ? (
                 <FlexRow>
-                  <Typography variant="default">
-                    {t('parkingTime', { time: formatDuration(durationFromPriceDate ?? 0) })}
-                  </Typography>
+                  <Typography variant="default">{t('creditNpkUsed')}</Typography>
                   <Typography variant="default-bold">
-                    {formatPrice(priceData.priceWithoutDiscount)}
+                    {formatDuration(priceData.creditNpkUsedSeconds)}
                   </Typography>
                 </FlexRow>
+              ) : null}
 
-                {/* Is this ever used? */}
-                {udr?.rpkInformation ? (
-                  <Panel className="bg-warning-light">
-                    <Typography>{udr.rpkInformation}</Typography>
-                  </Panel>
-                ) : null}
+              {priceData.creditBpkUsedSeconds ? (
+                <FlexRow>
+                  <Typography variant="default">{t('creditBpkUsed')}</Typography>
+                  <Typography variant="default-bold">
+                    {formatDuration(priceData.creditBpkUsedSeconds)}
+                  </Typography>
+                </FlexRow>
+              ) : null}
 
-                {udr?.npkInformation ? (
-                  <Panel className="bg-warning-light">
-                    <Typography>{udr.npkInformation}</Typography>
-                  </Panel>
-                ) : null}
+              {/* Check if it is present (null/undefined, but show if it is 0) */}
+              {priceData.tax == null ? null : (
+                <FlexRow>
+                  <Typography variant="default">{t('tax')}</Typography>
+                  <Typography variant="default-bold">{formatPrice(priceData.tax)}</Typography>
+                </FlexRow>
+              )}
 
-                {/* This usually says you cannot use BPK (in 2e zones) */}
-                {udr?.additionalInformation ? (
-                  <Panel className="bg-warning-light">
-                    <Typography>{udr.additionalInformation}</Typography>
-                  </Panel>
-                ) : null}
-
-                {priceData.creditNpkUsedSeconds ? (
-                  <FlexRow>
-                    <Typography variant="default">{t('creditNpkUsed')}</Typography>
-                    <Typography variant="default-bold">
-                      {formatDuration(priceData.creditNpkUsedSeconds)}
-                    </Typography>
-                  </FlexRow>
-                ) : null}
-
-                {priceData.creditBpkUsedSeconds ? (
-                  <FlexRow>
-                    <Typography variant="default">{t('creditBpkUsed')}</Typography>
-                    <Typography variant="default-bold">
-                      {formatDuration(priceData.creditBpkUsedSeconds)}
-                    </Typography>
-                  </FlexRow>
-                ) : null}
-
-                {/* Check if it is present (null/undefined, but show if it is 0) */}
-                {priceData.tax == null ? null : (
-                  <FlexRow>
-                    <Typography variant="default">{t('tax')}</Typography>
-                    <Typography variant="default-bold">{formatPrice(priceData.tax)}</Typography>
-                  </FlexRow>
-                )}
-
-                <Divider />
-              </>
-            ) : null}
-          </BottomSheetContent>
-        </BottomSheet>
-
-        <View
-          style={{ paddingBottom: insets.bottom }}
-          className={clsx('bg-white px-5 g-3')}
-          onLayout={(event) => {
-            setPurchaseButtonContainerHeight(event.nativeEvent.layout.height)
-          }}
-        >
-          {/* Toggling visibility instead hiding by "display: none" prevents layout shifts */}
-          <FlexRow className={priceData ? 'visible' : 'hidden'}>
-            <Typography variant="default-bold">{t('summary')}</Typography>
-            {priceData ? (
-              <Typography variant="default-bold">{formatPrice(priceData.priceTotal)}</Typography>
-            ) : null}
-          </FlexRow>
-
-          {error && !priceData ? (
-            <Panel className="bg-negative-light px-5 py-4">
-              <Typography>{t(`Errors.${error.errorName}`)}</Typography>
-            </Panel>
+              <Divider />
+            </>
           ) : null}
-
-          <Button onPress={handlePressPay} disabled={!priceData} loading={isLoading}>
-            {t('pay')}
-          </Button>
-        </View>
-      </>
+        </BottomSheetContent>
+      </BottomSheet>
     )
   },
 )

--- a/translations/en.json
+++ b/translations/en.json
@@ -40,11 +40,30 @@
     "chooseVehicleFieldLabel": "Choose vehicle",
     "customParkingTimeFieldLabel": "Choose time",
     "chooseParkingZoneEmptyControlLabel": "Choose parking zone",
+    "pay": "Pay",
+    "summary": "Summary",
     "backToMap": "Back to map",
     "paymentFailed": "Payment failed",
     "paymentFailedText": "Your payment has failed. \nPlease try again.",
     "paymentSuccessful": "Payment successful",
-    "paymentSuccessfulText": "Your payment ticket has been paid."
+    "paymentSuccessfulText": "Your payment ticket has been paid.",
+    "Errors": {
+      "TooLongParkingTime": "Maximum parking time is 48 hours",
+      "TooShortParkingTime": "TooShortParkingTime TODO",
+      "FreeTicket": "Not possible to buy parking ticket. Parking is not paid at specified time.",
+      "InsufficientCredit": "There is no sufficient credit on NPK card for this parking",
+      "CardNotValid": "NPK card is not valid",
+      "NoUsableParkingCardFound": "Invalid parking card type / parking card not found",
+      "PermitCardActive": "There is resident or abonent card on this Parking Space and ECV",
+      "InvalidParkingTime": "Invalid parking time, parking must end in the future.",
+      "InvalidParkingStart": "Ticket start is after ticket End",
+      "InvalidParkingEnd": "InvalidParkingEnd TODO",
+      "parkingSpaceNotFound": "Parking segment does not exist. Please try different parking segment ID.",
+      "TicketAlreadyExists": "This ticket for ecv {{ecv}} in parking space {{data.udr}} now already exists. It will end at {{data.parkingEnd}}",
+      "BadDateFormat": "Variable {{dateType}} has a bad format. You need ISO 8601 format",
+      "TicketAlreadyShortened": "TicketAlreadyShortened TODO",
+      "BadRequest": "Bad request"
+    }
   },
   "BoughtTicket": {
     "yourTicket": "Your ticket",
@@ -52,25 +71,10 @@
     "validUntil": "Valid to"
   },
   "PurchaseBottomSheet": {
-    "pay": "Pay",
-    "summary": "Summary",
     "parkingTime": "Parking {{time}}",
     "creditNpkUsed": "Visitor card",
     "creditBpkUsed": "Bonus card",
-    "tax": "Tax",
-    "Errors": {
-      "TooLongParkingTime": "Maximum parking time is 48 hours",
-      "FreeTicket": "Not possible to buy parking ticket. Parking is not paid at specified time.",
-      "InsufficientCredit": "There is no sufficent credit on NPK card for this parking",
-      "CardNotValid": "NPK card is not valid",
-      "NoUsableParkingCardFound": "Invalid parking card type / parking card not found",
-      "PermitCardActive": "There is resident or abonent card on this Parking Space and ECV",
-      "InvalidParkingTime": "Invalid parking time, parking must end in the future.",
-      "InvalidParkingStart": "Ticket start is after ticket End",
-      "parkingSpaceNotFound": "Parking segment does not exist. Please try different parking segment ID.",
-      "TicketAllreadyExists": "This ticket for ecv {{ecv}} in parking space {{data.udr}} now already exists. It will end at {{data.parkingEnd}}",
-      "BadDateFormat": "Variable {{dateType}} has a bad format. You need ISO 8601 format"
-    }
+    "tax": "Tax"
   },
   "VehiclesScreen": {
     "title": "Vehicles",
@@ -300,8 +304,8 @@
   "Errors": {
     "422": "An error occurred while processing your request. Please try again later.",
     "axiosGeneric": "An error occurred while processing your request. Please try again later.",
-    "generic": "An error occured.",
-    "DATABASE ERROR": "database error",
+    "generic": "An error occurred.",
+    "DATABASE_ERROR": "database error",
     "MAILGUN_ERROR": "mailgun error",
     "RABBIT_MQ_ERROR": "rabbit mq error"
   },

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -40,26 +40,16 @@
     "chooseVehicleFieldLabel": "Vyberte vozidlo",
     "customParkingTimeFieldLabel": "Vyberte čas",
     "chooseParkingZoneEmptyControlLabel": "Vyberte úsek parkovania",
+    "pay": "Zaplatiť",
+    "summary": "Celkom",
     "backToMap": "Späť na mapu",
     "paymentFailed": "Platba zlyhala",
     "paymentFailedText": "Mrzí nás to, vaša platba zlyhala.\nProsím, skúste to znova.",
     "paymentSuccessful": "Úspešná platba",
-    "paymentSuccessfulText": "Ďakujeme, váš parkovací lístok bol uhradený."
-  },
-  "BoughtTicket": {
-    "yourTicket": "Parkovací lístok",
-    "licencePlate": "Evidenčné číslo",
-    "validUntil": "Platnosť do"
-  },
-  "PurchaseBottomSheet": {
-    "pay": "Zaplatiť",
-    "summary": "Celkom",
-    "parkingTime": "Parkovanie {{time}}",
-    "creditNpkUsed": "Návštevnícka karta",
-    "creditBpkUsed": "Bonusová karta",
-    "tax": "Daň",
+    "paymentSuccessfulText": "Ďakujeme, váš parkovací lístok bol uhradený.",
     "Errors": {
       "TooLongParkingTime": "Prekročený maximálny čas na parkovanie",
+      "TooShortParkingTime": "TooShortParkingTime TODO",
       "FreeTicket": "Parkovací lístok nie je možné zakúpiť. Parkovanie sa v určenom čase neplatí.",
       "InsufficientCredit": "Pre toto parkovanie nie je na karte NPK dostatočný kredit",
       "CardNotValid": "Návštevnícka parkovacia karta nie je platná",
@@ -67,10 +57,24 @@
       "PermitCardActive": "Na tomto parkovacom mieste a EČV je rezidentská alebo abonentská karta",
       "InvalidParkingTime": "Neplatná doba parkovania, parkovanie musí skončiť v budúcnosti.",
       "InvalidParkingStart": "Začiatok lístka je po ukončení lístka",
+      "InvalidParkingEnd": "InvalidParkingEnd TODO",
       "parkingSpaceNotFound": "Parkovací segment neexistuje. Skúste iné ID parkovacieho segmentu.",
-      "TicketAllreadyExists": "Tento lístok pre ecv na parkovacom miest už existuje. Skončí o ...",
-      "BadDateFormat": "Premenná má zlý formát. Potrebujete formát ISO 8601"
+      "TicketAlreadyExists": "Tento lístok pre ecv na parkovacom miest už existuje. Skončí o ... TODO",
+      "BadDateFormat": "Premenná má zlý formát. Potrebujete formát ISO 8601",
+      "TicketAlreadyShortened": "TicketAlreadyShortened TODO",
+      "BadRequest": "Bad request"
     }
+  },
+  "BoughtTicket": {
+    "yourTicket": "Parkovací lístok",
+    "licencePlate": "Evidenčné číslo",
+    "validUntil": "Platnosť do"
+  },
+  "PurchaseBottomSheet": {
+    "parkingTime": "Parkovanie {{time}}",
+    "creditNpkUsed": "Návštevnícka karta",
+    "creditBpkUsed": "Bonusová karta",
+    "tax": "Daň"
   },
   "VehiclesScreen": {
     "title": "Vozidlá",
@@ -299,7 +303,7 @@
     "422": "Vyskytla sa chyba pri spracovaní vašej požiadavky. Skúste to prosím neskôr.",
     "axiosGeneric": "Pri spracovaní vašej požiadavky sa vyskytla chyba. Skúste to prosím neskôr.",
     "generic": "Vyskytla sa chyba.",
-    "DATABASE ERROR": "chyba databázy",
+    "DATABASE_ERROR": "chyba databázy",
     "MAILGUN_ERROR": "chyba mailgunu",
     "RABBIT_MQ_ERROR": "chyba rabbit mq"
   },

--- a/utils/errorPricingApi.ts
+++ b/utils/errorPricingApi.ts
@@ -1,0 +1,17 @@
+import { PRICINGAPIERROR } from '@/modules/backend/openapi-generated'
+import { isError } from '@/utils/errors'
+
+export class PricingApiError extends Error {
+  errorName: PRICINGAPIERROR
+
+  constructor(message: string, errorName: PRICINGAPIERROR) {
+    super(message)
+    this.errorName = errorName
+  }
+}
+
+export const isPricingApiError = (error: unknown): error is PricingApiError =>
+  isError(error) &&
+  'errorName' in error &&
+  typeof error.errorName === 'string' &&
+  error.errorName in PRICINGAPIERROR

--- a/utils/isDefined.ts
+++ b/utils/isDefined.ts
@@ -1,0 +1,3 @@
+export function isDefined<T>(value: T | undefined | null): value is T {
+  return value !== undefined && value !== null
+}


### PR DESCRIPTION
- redirect directly to confirmation screen on purchases that are zero price (NPK, BPK)
- add translations keys for missing errors - TODO translations
- re-organize components in purchase screen
  - move Pay button to main purchase screen
  - keep only additional details in PurchaseBottomSheet
  - create `PurchaseSummaryRow` and `PurchaseErrorPanel` to separate components
- check pricing api error to display `PurchaseErrorPanel` only for code 422 and `errorName` that matcher pricing api error
- fix duration from custom time