### PR TITLE
keep last selected language when logging out

### DIFF
--- a/app/(app)/settings/language.tsx
+++ b/app/(app)/settings/language.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { router } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, View } from 'react-native'
+import { useMMKVString } from 'react-native-mmkv'
 
 import ActionRow from '@/components/list-rows/ActionRow'
 import ScreenContent from '@/components/screen-layout/ScreenContent'
@@ -13,11 +14,13 @@ import { useTranslation as useTranslationLocal } from '@/hooks/useTranslation'
 import { clientApi } from '@/modules/backend/client-api'
 import { settingsOptions } from '@/modules/backend/constants/queryOptions'
 import { SaveUserSettingsDto } from '@/modules/backend/openapi-generated'
+import { STORAGE_LANGUAGE_KEY } from '@/utils/mmkv'
 
 const Page = () => {
   const t = useTranslationLocal('Settings')
   const { i18n } = useTranslation()
   const queryClient = useQueryClient()
+  const [, setMmkvLocale] = useMMKVString(STORAGE_LANGUAGE_KEY)
 
   const mutation = useMutation({
     mutationFn: (body: SaveUserSettingsDto) => clientApi.usersControllerSaveUserSettings(body),
@@ -32,8 +35,9 @@ const Page = () => {
 
   const handleLanguageChange = async (newLanguage: 'sk' | 'en') => {
     if (newLanguage !== language) {
-      await i18n.changeLanguage(newLanguage)
       await mutation.mutateAsync({ language: newLanguage })
+      await i18n.changeLanguage(newLanguage)
+      setMmkvLocale(newLanguage)
     }
 
     if (router.canGoBack()) {

--- a/app/(auth)/confirm-sign-in.tsx
+++ b/app/(auth)/confirm-sign-in.tsx
@@ -2,6 +2,7 @@ import { useLocalSearchParams } from 'expo-router'
 import { useState } from 'react'
 import { useTranslation as useLibTranslation } from 'react-i18next'
 import { View } from 'react-native'
+import { useMMKVString } from 'react-native-mmkv'
 
 import CodeInput from '@/components/inputs/CodeInput'
 import ContinueButton from '@/components/navigation/ContinueButton'
@@ -14,6 +15,7 @@ import { useSignInOrSignUp } from '@/hooks/useSignInOrSignUp'
 import { useTranslation } from '@/hooks/useTranslation'
 import { changeUserLanguageToDevice } from '@/utils/changeUserLanguageToDevice'
 import { isErrorWithName } from '@/utils/errorCognitoAuth'
+import { STORAGE_LANGUAGE_KEY } from '@/utils/mmkv'
 
 type ConfirmAuthSearchParams = {
   phone: string
@@ -22,6 +24,7 @@ type ConfirmAuthSearchParams = {
 const Page = () => {
   const t = useTranslation('Auth')
   const { i18n } = useLibTranslation()
+  const [, setMmkvLocale] = useMMKVString(STORAGE_LANGUAGE_KEY)
 
   const { attemptConfirmSignIn, resendConfirmationCode } = useSignInOrSignUp()
   const { phone } = useLocalSearchParams<ConfirmAuthSearchParams>()
@@ -49,6 +52,7 @@ const Page = () => {
 
         if (newLanguage) {
           await i18n.changeLanguage(newLanguage)
+          setMmkvLocale(newLanguage)
         }
       } catch (error) {
         if (isErrorWithName(error)) {

--- a/components/controls/LangugageSelectField.tsx
+++ b/components/controls/LangugageSelectField.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'expo-router'
 import { useEffect } from 'react'
 import { useTranslation as useLibTranslation } from 'react-i18next'
+import { useMMKVString } from 'react-native-mmkv'
 
 import Field from '@/components/shared/Field'
 import FlexRow from '@/components/shared/FlexRow'
@@ -11,18 +12,23 @@ import Typography from '@/components/shared/Typography'
 import { useQueryWithFocusRefetch } from '@/hooks/useQueryWithFocusRefetch'
 import { useTranslation } from '@/hooks/useTranslation'
 import { settingsOptions } from '@/modules/backend/constants/queryOptions'
+import { STORAGE_LANGUAGE_KEY } from '@/utils/mmkv'
 
 const LangugageSelectField = () => {
   const t = useTranslation('Settings')
   const { i18n } = useLibTranslation()
+  const [, setMmkvLocale] = useMMKVString(STORAGE_LANGUAGE_KEY)
 
   const { data, isPending, isRefetching } = useQueryWithFocusRefetch(settingsOptions())
 
   useEffect(() => {
-    if (data?.data.language && data.data.language !== i18n.language) {
-      i18n.changeLanguage(data?.data.language)
+    const apiLanguage = data?.data.language
+
+    if (apiLanguage && apiLanguage !== i18n.language) {
+      i18n.changeLanguage(apiLanguage)
+      setMmkvLocale(apiLanguage)
     }
-  }, [data?.data.language, i18n])
+  }, [data?.data.language, i18n, setMmkvLocale])
 
   const languages = { sk: 'Slovenčina', en: 'English' }
 

--- a/utils/changeUserLanguageToDevice.ts
+++ b/utils/changeUserLanguageToDevice.ts
@@ -1,6 +1,7 @@
 import * as Localization from 'expo-localization'
 
 import { clientApi } from '@/modules/backend/client-api'
+import { storage, STORAGE_LANGUAGE_KEY } from '@/utils/mmkv'
 
 export const enabledLocales = new Set(['en', 'sk'])
 
@@ -16,16 +17,18 @@ type Options = {
 export const changeUserLanguageToDevice = async (options?: Options) => {
   const deviceLocale = Localization.locale.split('-')[0]
 
-  let appLocale = enabledLocales.has(deviceLocale) ? deviceLocale : 'en'
+  const mmkvLocale = storage.getString(STORAGE_LANGUAGE_KEY)
+
+  let appLocale = mmkvLocale ?? (enabledLocales.has(deviceLocale) ? deviceLocale : 'en')
 
   if (!options?.skipCheck) {
     const response = await clientApi.usersControllerGetUserSettings()
-    const storedLocale = response?.data?.language
+    const apiLocale = response?.data?.language
 
-    if (storedLocale === appLocale) {
+    if (apiLocale === appLocale) {
       return null
     }
-    if (storedLocale) appLocale = storedLocale
+    if (apiLocale) appLocale = apiLocale
   }
 
   try {


### PR DESCRIPTION
adding language also to MMKV storage to keep the last language stored in case of logging out (closes #376)

there was a bug that if I log out, kill app and then open it again the device language will be used 

now the priority order is: API language -  mmkv language - device language.

if there is difference in api and mmkv language the api will rewrite mmkv language