### PR TITLE
debouncing duration

### DIFF
--- a/app/(app)/(purchase-and-payment)/prolongate/[ticketId]/index.tsx
+++ b/app/(app)/(purchase-and-payment)/prolongate/[ticketId]/index.tsx
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query'
 import { Link } from 'expo-router'
 import { useState } from 'react'
 import { ScrollView } from 'react-native'
+import { useDebounce } from 'use-debounce'
 
 import TimeSelector from '@/components/controls/date-time/TimeSelector'
 import PaymentMethodsFieldControl from '@/components/controls/payment-methods/PaymentMethodsFieldControl'
@@ -35,8 +36,11 @@ const ProlongTicketScreen = () => {
 
   const [defaultPaymentOption] = useDefaultPaymentOption()
 
+  const [debouncedDuration] = useDebounce(duration, 500)
+  const isDebouncingDuration = duration !== debouncedDuration
+
   const activeTicketEnd = new Date(ticket?.parkingEnd ?? Date.now()).getTime()
-  const parkingEnd = new Date(activeTicketEnd + duration * 1000).toISOString()
+  const parkingEnd = new Date(activeTicketEnd + debouncedDuration * 1000).toISOString()
 
   const initPaymentMutation = useMutation({
     mutationFn: (bodyInner: InitiateProlongationRequestDto) =>
@@ -132,7 +136,7 @@ const ProlongTicketScreen = () => {
         handlePressPay={handlePressPay}
         purchaseButtonContainerHeight={purchaseButtonContainerHeight}
         setPurchaseButtonContainerHeight={setPurchaseButtonContainerHeight}
-        isLoading={initPaymentMutation.isPending}
+        isLoading={initPaymentMutation.isPending || isDebouncingDuration}
       />
     </>
   )

--- a/utils/createPriceRequestBody.ts
+++ b/utils/createPriceRequestBody.ts
@@ -2,8 +2,8 @@ import { ParkingCardDto } from '@/modules/backend/openapi-generated'
 import { MapUdrZone } from '@/modules/map/types'
 
 /**
- * Function to create price request body needed for having fresh parkingStart and parkingEnd
- * otherwise useMemo would store old time values and it cannot be changed to new ones without having infinite loop
+ * Function to create price request body needed for having fresh parkingStart
+ * otherwise useMemo would store old time value and it cannot be changed to new one without having infinite loop
  * @param param0 object with udr, licencePlate, duration, npk
  * @returns price request body
  */

--- a/utils/createPriceRequestBody.ts
+++ b/utils/createPriceRequestBody.ts
@@ -1,0 +1,35 @@
+import { ParkingCardDto } from '@/modules/backend/openapi-generated'
+import { MapUdrZone } from '@/modules/map/types'
+
+/**
+ * Function to create price request body needed for having fresh parkingStart and parkingEnd
+ * otherwise useMemo would store old time values and it cannot be changed to new ones without having infinite loop
+ * @param param0 object with udr, licencePlate, duration, npk
+ * @returns price request body
+ */
+export const createPriceRequestBody = ({
+  udr,
+  licencePlate,
+  duration,
+  npk,
+}: {
+  udr: MapUdrZone | null
+  licencePlate: string
+  duration: number
+  npk: ParkingCardDto | null
+}) => {
+  const dateNow = Date.now()
+  const parkingStart = new Date(dateNow).toISOString()
+  const parkingEnd = new Date(dateNow + duration * 1000).toISOString()
+
+  return {
+    npkId: npk?.identificator || undefined,
+    ticket: {
+      udr: String(udr?.udrId) ?? '',
+      udrUuid: udr?.udrUuid ?? '',
+      ecv: licencePlate ?? '',
+      parkingStart,
+      parkingEnd,
+    },
+  }
+}


### PR DESCRIPTION
- added debounce for the duration in price calculation (both prolongation and first purchase) (closes #357)
the first purchase has to have a separate function to have the freshest parkingStart when clicking the pay button
prolongation doesn't have this usecase because using parkingStart from an old ticket and not the current time