### PR TITLE
caching gis data

### DIFF
--- a/modules/arcgis/hooks/useStaticArcgisData.ts
+++ b/modules/arcgis/hooks/useStaticArcgisData.ts
@@ -22,6 +22,8 @@ async function fetchFileOrGetFromCache<T>(fileName: string): Promise<AxiosRespon
 
     const responseHeaders = await axios.head<T>(url)
 
+    // Etag is an identifier for a specific version of a resource.
+    // If the etag is the same, we can use the cached response
     if (responseHeaders.headers.etag === cachedParsedResponse?.headers?.etag) {
       return cachedParsedResponse
     }

--- a/modules/arcgis/hooks/useStaticArcgisData.ts
+++ b/modules/arcgis/hooks/useStaticArcgisData.ts
@@ -1,60 +1,88 @@
 import { useQuery } from '@tanstack/react-query'
-import axios from 'axios'
+import axios, { AxiosResponse } from 'axios'
 import { FeatureCollection, GeoJsonProperties, Point, Polygon } from 'geojson'
 
 import { ArcgisAliased } from '@/modules/arcgis/aliasedTypes'
 import { STATIC_ARCGIS_URL } from '@/modules/arcgis/constants'
 import { Arcgis, ArcgisData } from '@/modules/arcgis/types'
+import { storage } from '@/utils/mmkv'
+
+/**
+ * Function to fetch a file from the static arcgis server or get it from the cache
+ * @param fileName name of the file to fetch
+ * @returns Promise with the file response
+ */
+async function fetchFileOrGetFromCache<T>(fileName: string): Promise<AxiosResponse<T>> {
+  const url = `${STATIC_ARCGIS_URL}/${fileName}`
+
+  const cachedResponse = storage.getString(url)
+
+  if (cachedResponse) {
+    const cachedParsedResponse = JSON.parse(cachedResponse) as AxiosResponse<T>
+
+    const responseHeaders = await axios.head<T>(url)
+
+    if (responseHeaders.headers.etag === cachedParsedResponse?.headers?.etag) {
+      return cachedParsedResponse
+    }
+  }
+
+  const response = await axios.get<T>(url)
+
+  storage.set(url, JSON.stringify(response))
+
+  return response
+}
 
 export const useStaticArcgisData = (): Partial<ArcgisData> => {
   const { data: rawZonesData } = useQuery({
     queryKey: ['RawZonesData'],
     queryFn: () =>
-      axios.get<FeatureCollection<Polygon, GeoJsonProperties>>(`${STATIC_ARCGIS_URL}/okp.geojson`),
+      fetchFileOrGetFromCache<FeatureCollection<Polygon, GeoJsonProperties>>('okp.geojson'),
     select: (data) => data.data,
   })
 
   const { data: rawParkomatsData } = useQuery({
     queryKey: ['RawParkomatsData'],
     queryFn: () =>
-      axios.get<FeatureCollection<Point, Arcgis.ParkomatPoint | ArcgisAliased.ParkomatPoint>>(
-        `${STATIC_ARCGIS_URL}/parkomaty.geojson`,
-      ),
+      fetchFileOrGetFromCache<
+        FeatureCollection<Point, Arcgis.ParkomatPoint | ArcgisAliased.ParkomatPoint>
+      >('parkomaty.geojson'),
     select: (data) => data.data,
   })
 
   const { data: rawPartnersData } = useQuery({
     queryKey: ['RawPartnersData'],
     queryFn: () =>
-      axios.get<FeatureCollection<Point, Arcgis.PartnerPoint | ArcgisAliased.PartnerPoint>>(
-        `${STATIC_ARCGIS_URL}/partnerske_prevadzky.geojson`,
-      ),
+      fetchFileOrGetFromCache<
+        FeatureCollection<Point, Arcgis.PartnerPoint | ArcgisAliased.PartnerPoint>
+      >('partnerske_prevadzky.geojson'),
     select: (data) => data.data,
   })
 
   const { data: rawParkingLotsData } = useQuery({
     queryKey: ['RawParkingLotsData'],
     queryFn: () =>
-      axios.get<FeatureCollection<Point, Arcgis.ParkingPoint | ArcgisAliased.ParkingPoint>>(
-        `${STATIC_ARCGIS_URL}/parkoviska.geojson`,
-      ),
+      fetchFileOrGetFromCache<
+        FeatureCollection<Point, Arcgis.ParkingPoint | ArcgisAliased.ParkingPoint>
+      >('parkoviska.geojson'),
     select: (data) => data.data,
   })
 
   const { data: rawBranchesData } = useQuery({
     queryKey: ['RawBranchesData'],
     queryFn: () =>
-      axios.get<FeatureCollection<Point, Arcgis.BranchPoint | ArcgisAliased.BranchPoint>>(
-        `${STATIC_ARCGIS_URL}/pobocky.geojson`,
-      ),
+      fetchFileOrGetFromCache<
+        FeatureCollection<Point, Arcgis.BranchPoint | ArcgisAliased.BranchPoint>
+      >('pobocky.geojson'),
     select: (data) => data.data,
   })
 
   const { data: rawUdrData } = useQuery({
     queryKey: ['RawUdrData'],
     queryFn: () =>
-      axios.get<FeatureCollection<Polygon, Arcgis.UdrZone | ArcgisAliased.UdrZone>>(
-        `${STATIC_ARCGIS_URL}/udr_p.geojson`,
+      fetchFileOrGetFromCache<FeatureCollection<Polygon, Arcgis.UdrZone | ArcgisAliased.UdrZone>>(
+        'udr_p.geojson',
       ),
     select: (data) => data.data,
   })
@@ -62,7 +90,7 @@ export const useStaticArcgisData = (): Partial<ArcgisData> => {
   const { data: rawOdpData } = useQuery({
     queryKey: ['RawOdpData'],
     queryFn: () =>
-      axios.get<FeatureCollection<Polygon, GeoJsonProperties>>(`${STATIC_ARCGIS_URL}/odp.geojson`),
+      fetchFileOrGetFromCache<FeatureCollection<Polygon, GeoJsonProperties>>('odp.geojson'),
     select: (data) => data.data,
   })
 


### PR DESCRIPTION
caching data from gis (closes #350)
- it's done by fetching only headers first and checking etag value which will be compared (etag is version of the file) and if so the new data are fetched.