### PR TITLE
Bugfix bottom sheet

### DIFF
--- a/components/controls/date-time/DateTimePicker.tsx
+++ b/components/controls/date-time/DateTimePicker.tsx
@@ -43,7 +43,7 @@ const DateTimePicker = ({ onConfirm, onClose, open }: Props) => {
         // maximumDate={} // TODO set maximum time
         date={date}
         onDateChange={handleDateChanged}
-        androidVariant="iosClone"
+        androidVariant="nativeAndroid"
         locale={locale}
         is24hourSource="locale"
         modal

--- a/components/map/MapLocationBottomSheet.tsx
+++ b/components/map/MapLocationBottomSheet.tsx
@@ -19,10 +19,13 @@ const MapLocationBottomSheet = () => {
   const [isLocationOn, setIsLocationOn] = useState(true)
 
   const reloadLocationStatus = useCallback(async () => {
-    getLocationPermission()
+    if (locationPermissionStatus === Location.PermissionStatus.UNDETERMINED) {
+      await getLocationPermission()
+    }
+
     const isEnabled = await Location.hasServicesEnabledAsync()
     setIsLocationOn(isEnabled)
-  }, [getLocationPermission])
+  }, [getLocationPermission, locationPermissionStatus])
 
   const handleOpenSettingsPress = useCallback(async () => {
     if (locationPermissionStatus !== Location.PermissionStatus.GRANTED) {
@@ -64,6 +67,7 @@ const MapLocationBottomSheet = () => {
   return (
     <BottomSheet
       ref={ref}
+      key="mapLocationBottomSheet"
       handleComponent={BottomSheetHandleWithShadow}
       enablePanDownToClose
       enableDynamicSizing

--- a/components/map/MapScreen.tsx
+++ b/components/map/MapScreen.tsx
@@ -109,13 +109,11 @@ const MapScreen = ({ onMapStateChange }: Props) => {
           isZoomedOut={!isMapPinShown}
           address={currentAddress}
         />
-      </Portal>
-      {selectedMapPoint && (
-        <Portal hostName="index">
+
+        {selectedMapPoint && (
           <MapPointBottomSheet ref={pointBottomSheetRef} point={selectedMapPoint} />
-        </Portal>
-      )}
-      <Portal hostName="index">
+        )}
+
         <MapLocationBottomSheet />
       </Portal>
       <View className="absolute left-0 px-2.5" style={{ top }}>

--- a/components/map/MapZoneBottomSheet.tsx
+++ b/components/map/MapZoneBottomSheet.tsx
@@ -14,7 +14,6 @@ import BottomSheetHandleWithShadow from '@/components/screen-layout/BottomSheet/
 import Field from '@/components/shared/Field'
 import PressableStyled from '@/components/shared/PressableStyled'
 import Typography from '@/components/shared/Typography'
-import { useMultipleRefsSetter } from '@/hooks/useMultipleRefsSetter'
 import { useTranslation } from '@/hooks/useTranslation'
 import { MapUdrZone } from '@/modules/map/types'
 
@@ -28,9 +27,7 @@ type Props = {
 const MapZoneBottomSheet = forwardRef<BottomSheet, Props>((props, ref) => {
   const { zone: selectedZone, setFlyToCenter, isZoomedOut, address } = props
 
-  const localRef = useRef<BottomSheet>(null)
   const inputRef = useRef<RNTextInput>(null)
-  const refSetter = useMultipleRefsSetter(ref, localRef)
 
   const t = useTranslation('ZoneBottomSheet')
 
@@ -44,7 +41,8 @@ const MapZoneBottomSheet = forwardRef<BottomSheet, Props>((props, ref) => {
     <>
       <MapZoneBottomSheetAttachment {...{ animatedPosition, setFlyToCenter }} />
       <BottomSheet
-        ref={refSetter}
+        key="mapZoneBottomSheet"
+        ref={ref}
         keyboardBehavior="interactive"
         handleComponent={BottomSheetHandleWithShadow}
         animatedPosition={animatedPosition}

--- a/components/map/MapZoneBottomSheetAttachment.tsx
+++ b/components/map/MapZoneBottomSheetAttachment.tsx
@@ -13,7 +13,6 @@ import Icon from '@/components/shared/Icon'
 import IconButton from '@/components/shared/IconButton'
 import PressableStyled from '@/components/shared/PressableStyled'
 import Typography from '@/components/shared/Typography'
-import { useAppFocusEffect } from '@/hooks/useAppFocusEffect'
 import { useQueryInvalidateOnTicketExpire } from '@/hooks/useQueryInvalidateOnTicketExpire'
 import { useQueryWithFocusRefetch } from '@/hooks/useQueryWithFocusRefetch'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -30,7 +29,7 @@ type Props = Omit<BottomSheetTopAttachmentProps, 'children'> & {
 
 const MapZoneBottomSheetAttachment = ({ setFlyToCenter, ...restProps }: Props) => {
   const t = useTranslation('ZoneBottomSheet.TopAttachment')
-  const [permissionStatus, getPermissionStatus] = useLocationPermission()
+  const [permissionStatus] = useLocationPermission()
   const [isButtonDisabled, setIsButtonDisabled] = useState(false)
   const [isButtonDisabledTimeout, setIsButtonDisabledTimeout] = useState<NodeJS.Timeout | null>(
     null,
@@ -69,8 +68,6 @@ const MapZoneBottomSheetAttachment = ({ setFlyToCenter, ...restProps }: Props) =
     refetch,
     activeTicketsOptions().queryKey,
   )
-
-  useAppFocusEffect(getPermissionStatus)
 
   useEffect(() => {
     return () => {

--- a/components/screen-layout/StackScreenWithHeader.tsx
+++ b/components/screen-layout/StackScreenWithHeader.tsx
@@ -91,6 +91,7 @@ const StackScreenWithHeader = ({ options, ...passingProps }: Props) => {
     <Stack.Screen
       options={{
         headerShown: true,
+        animation: options?.presentation === 'modal' ? 'slide_from_bottom' : undefined,
         ...options,
         header: isModalOnIOS ? undefined : renderHeader,
         headerLeft: isModalOnIOS ? renderHeaderLeft : undefined,

--- a/modules/map/hooks/useNotificationPermission.ts
+++ b/modules/map/hooks/useNotificationPermission.ts
@@ -2,7 +2,6 @@ import messaging from '@react-native-firebase/messaging'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import * as Device from 'expo-device'
 import { PermissionStatus } from 'expo-modules-core'
-import { router } from 'expo-router'
 import { useCallback, useEffect, useState } from 'react'
 import { Platform } from 'react-native'
 
@@ -81,8 +80,7 @@ export const useNotificationPermission = ({ autoAsk, skipTokenQuery }: Options =
       }
     } else {
       console.warn('Must use physical device for Push Notifications, skipping.')
-      // If on simulator, continue to homepage
-      router.push('/')
+      setPermissionStatus(PermissionStatus.DENIED)
     }
   }, [checkAndRegisterToken])
 


### PR DESCRIPTION
- changed requesting location functions to ask only once when it's not determined or when denied and `canAskAgain` is true (closes #416),
- gps ask twice fix by removing it from MapZoneBottomSheetAttachment component (closes #403),
- removed unnecessary ref,
- one portal instead of three,
- simulator permissions screen navigated from navigation to homescreen, now it navigates to location permissions screen,
- changed datepicker on android (closes #417),
- android `presentation: "modal"` screens are now sliding from bottom (closes #415)