### PR TITLE
disabled notifications and removing device when logging out

### DIFF
--- a/app/permissions.tsx
+++ b/app/permissions.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx'
-import { PermissionStatus } from 'expo-modules-core'
 import { router, Stack } from 'expo-router'
 import { useCallback, useEffect, useState } from 'react'
 import { useWindowDimensions, View } from 'react-native'
@@ -12,6 +11,7 @@ import InfoSlide from '@/components/screen-layout/InfoSlide'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useLocationPermission } from '@/modules/map/hooks/useLocationPermission'
 import { useNotificationPermission } from '@/modules/map/hooks/useNotificationPermission'
+import { PermissionStatus } from '@/utils/types'
 
 type RouteKeys = 'notifications' | 'location'
 // key is nested inside router, because this is how `renderScene` provides it

--- a/components/controls/notifications/SwitchControl.tsx
+++ b/components/controls/notifications/SwitchControl.tsx
@@ -9,6 +9,7 @@ export type SwitchControlProps = {
   title: string
   description?: string
   value: boolean
+  disabled?: boolean
   accessibilityLabel: string
   onValueChange: SwitchProps['onValueChange']
 }
@@ -16,6 +17,7 @@ export type SwitchControlProps = {
 const SwitchControl = ({
   title,
   description,
+  disabled,
   value,
   accessibilityLabel,
   onValueChange,
@@ -30,6 +32,7 @@ const SwitchControl = ({
 
         <View>
           <Switch
+            disabled={disabled}
             accessibilityLabel={accessibilityLabel}
             value={value}
             onValueChange={onValueChange}

--- a/hooks/useSignInOrSignUp.ts
+++ b/hooks/useSignInOrSignUp.ts
@@ -1,5 +1,5 @@
 import { confirmSignIn, signIn, signOut, signUp } from 'aws-amplify/auth'
-import { PermissionStatus } from 'expo-modules-core'
+import * as Location from 'expo-location'
 import { router } from 'expo-router'
 
 import { useSnackbar } from '@/components/screen-layout/Snackbar/useSnackbar'
@@ -16,6 +16,7 @@ import { useNotificationPermission } from '@/modules/map/hooks/useNotificationPe
 import { useAuthStoreUpdateContext } from '@/state/AuthStoreProvider/useAuthStoreUpdateContext'
 import { isErrorWithName } from '@/utils/errorCognitoAuth'
 import { isError } from '@/utils/errors'
+import { PermissionStatus } from '@/utils/types'
 
 import { useIsOnboardingFinished } from './useIsOnboardingFinished'
 
@@ -135,7 +136,7 @@ export const useSignInOrSignUp = () => {
       }
 
       if (
-        locationPermissionStatus === PermissionStatus.UNDETERMINED ||
+        locationPermissionStatus === Location.PermissionStatus.UNDETERMINED ||
         notificationsPermissionStatus === PermissionStatus.UNDETERMINED
       ) {
         router.replace('/permissions')

--- a/modules/cognito/hooks/useSignOut.ts
+++ b/modules/cognito/hooks/useSignOut.ts
@@ -40,7 +40,7 @@ export const useSignOut = () => {
       await signOut()
       // cleanup the store and redirect to sign in
       onAuthStoreUpdate({ user: null })
-      router.push('/sign-in')
+      router.replace('/sign-in')
     } catch (error) {
       console.log('error signing out', error)
     }

--- a/modules/cognito/hooks/useSignOut.ts
+++ b/modules/cognito/hooks/useSignOut.ts
@@ -1,6 +1,11 @@
+import messaging from '@react-native-firebase/messaging'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { signOut } from 'aws-amplify/auth'
+import * as Device from 'expo-device'
 import { router } from 'expo-router'
 
+import { clientApi } from '@/modules/backend/client-api'
+import { devicesOptions } from '@/modules/backend/constants/queryOptions'
 import { useAuthStoreUpdateContext } from '@/state/AuthStoreProvider/useAuthStoreUpdateContext'
 
 /**
@@ -10,9 +15,30 @@ import { useAuthStoreUpdateContext } from '@/state/AuthStoreProvider/useAuthStor
 export const useSignOut = () => {
   const onAuthStoreUpdate = useAuthStoreUpdateContext()
 
+  const { data } = useQuery(devicesOptions())
+
+  const registerDeviceMutation = useMutation({
+    mutationFn: async (id: number) => clientApi.mobileDevicesControllerDeleteMobileDevice(id),
+  })
+
   return async () => {
     try {
+      // unregister device from notifications
+      if (Device.isDevice) {
+        try {
+          const token = await messaging().getToken()
+          const deviceId = data?.devices.find((device) => device.token === token)?.id
+
+          if (deviceId) {
+            registerDeviceMutation.mutate(deviceId)
+          }
+        } catch {
+          console.log('error during unregistering device from notifications')
+        }
+      }
+      // signout from cognito
       await signOut()
+      // cleanup the store and redirect to sign in
       onAuthStoreUpdate({ user: null })
       router.push('/sign-in')
     } catch (error) {

--- a/modules/map/hooks/useNotificationPermission.ts
+++ b/modules/map/hooks/useNotificationPermission.ts
@@ -1,13 +1,13 @@
 import messaging from '@react-native-firebase/messaging'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import * as Device from 'expo-device'
-import { PermissionStatus } from 'expo-modules-core'
 import { useCallback, useEffect, useState } from 'react'
 import { Platform } from 'react-native'
 
 import { clientApi } from '@/modules/backend/client-api'
 import { devicesOptions } from '@/modules/backend/constants/queryOptions'
 import { MobileDevicePlatform } from '@/modules/backend/openapi-generated'
+import { PermissionStatus } from '@/utils/types'
 
 type Options =
   | {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "expo-linking": "~5.0.2",
     "expo-localization": "~14.3.0",
     "expo-location": "~16.1.0",
-    "expo-modules-core": "~1.5.12",
     "expo-router": "~2.0.12",
     "expo-secure-store": "~12.3.1",
     "expo-status-bar": "~1.6.0",

--- a/translations/en.json
+++ b/translations/en.json
@@ -184,6 +184,8 @@
     "system": "System",
     "pushNotifications": "Push notifications",
     "emailNotifications": "Email notifications",
+    "notificationsDisabled": "Notifications are not enabled on your device.",
+    "notificationButtonText": "Enable notifications",
     "loading": "Loading",
     "type": {
       "pushNotificationsAboutToEnd": {

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -186,6 +186,9 @@
     "system": "Systém",
     "pushNotifications": "Push notifikácie",
     "emailNotifications": "E-mailové notifikácie",
+    "notificationsDisabled": "Notifikácie nie sú povolené na tomto zariadení.",
+    "notificationButtonText": "Povoliť notifikácie",
+
     "type": {
       "pushNotificationsAboutToEnd": {
         "title": "Parkovanie sa blíži ku koncu",

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -14,3 +14,21 @@ export type Unpromise<T extends Promise<any>> = T extends Promise<infer U> ? U :
  *          // Bar is { a: string; b?: string }
  */
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
+
+/**
+ * Permission status used with notifications
+ */
+export enum PermissionStatus {
+  /**
+   * User has granted the permission.
+   */
+  GRANTED = 'granted',
+  /**
+   * User hasn't granted or denied the permission yet.
+   */
+  UNDETERMINED = 'undetermined',
+  /**
+   * User has denied the permission.
+   */
+  DENIED = 'denied',
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6625,14 +6625,6 @@ expo-modules-core@1.5.11:
     compare-versions "^3.4.0"
     invariant "^2.2.4"
 
-expo-modules-core@~1.5.12:
-  version "1.5.12"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.5.12.tgz#07eb4de4bf25a3ec3e1924403e73d13c656613fd"
-  integrity sha512-mY4wTDU458dhwk7IVxLNkePlYXjs9BTgk4NQHBUXf0LapXsvr+i711qPZaFNO4egf5qq6fQV+Yfd/KUguHstnQ==
-  dependencies:
-    compare-versions "^3.4.0"
-    invariant "^2.2.4"
-
 expo-router@~2.0.12:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/expo-router/-/expo-router-2.0.12.tgz#04fd151bfa3b9e7605e83d132419c42b20fe0c1d"


### PR DESCRIPTION
- removed device from API on logout to not send notifications to logged out device,
- info panel to inform that it's forbidden to enable app notifications when they are disabled in device settings
- disabled push notification settings when the notifications are disabled in device settings