### PR TITLE
multiple route replacements fix

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -42,7 +42,7 @@ const RootLayout = () => {
   if (!user) {
     // On web, static rendering will stop here as the user is not authenticated
     // in the headless Node process that the pages are rendered in.
-    return <Redirect href="/sign-in" />
+    return <Redirect href="/onboarding" />
   }
 
   // Render the children routes now that all the assets are loaded.

--- a/modules/backend/axios-instance.ts
+++ b/modules/backend/axios-instance.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import { getAccessTokenOrLogout } from '@/modules/cognito/utils'
+import { getAccessToken } from '@/modules/cognito/utils'
 
 export const axiosInstance = axios.create()
 
@@ -13,7 +13,7 @@ declare module 'axios' {
 }
 
 axiosInstance.interceptors.request.use(async (request) => {
-  const accessToken = await getAccessTokenOrLogout()
+  const accessToken = await getAccessToken()
 
   if (accessToken) {
     request.headers.Authorization = `Bearer ${accessToken.toString()}`

--- a/modules/backend/hooks/usePrefetchOnAppStart.tsx
+++ b/modules/backend/hooks/usePrefetchOnAppStart.tsx
@@ -5,14 +5,14 @@ import { InteractionManager } from 'react-native'
 import { useLocale } from '@/hooks/useTranslation'
 import { clientApi } from '@/modules/backend/client-api'
 import { announcementsOptions, visitorCardsOptions } from '@/modules/backend/constants/queryOptions'
-import { getAccessTokenOrLogout } from '@/modules/cognito/utils'
+import { getAccessToken } from '@/modules/cognito/utils'
 
 export const usePrefetchOnAppStart = () => {
   const queryClient = useQueryClient()
   const locale = useLocale()
 
   const prefetch = useCallback(async () => {
-    const token = await getAccessTokenOrLogout()
+    const token = await getAccessToken()
 
     /* Do not prefetch if user is not logged in */
     if (!token) {

--- a/modules/cognito/utils.ts
+++ b/modules/cognito/utils.ts
@@ -8,7 +8,7 @@ export const STATIC_PHONE = '+42100000000'
 /**
  * Docs: https://docs.amplify.aws/react-native/build-a-backend/auth/manage-user-session/#retrieve-a-user-session
  */
-export const getAccessTokenOrLogout = async () => {
+export const getAccessToken = async () => {
   try {
     const session = await fetchAuthSession()
     const { accessToken } = session.tokens ?? {}
@@ -19,8 +19,7 @@ export const getAccessTokenOrLogout = async () => {
 
     return accessToken
   } catch (error) {
-    console.log('error getting access token - redirect to login', error)
-    router.replace('/onboarding')
+    console.log('error getting access token', error)
 
     return null
   }


### PR DESCRIPTION
- when opening app without access token route change was called twice or more times (now it's only necessary one-time call)