### PR TITLE
Remove useMemo from parkingEnd date in Tickets History screen, use better names

### DIFF
--- a/app/(app)/tickets/filters/timeframes.tsx
+++ b/app/(app)/tickets/filters/timeframes.tsx
@@ -7,7 +7,7 @@ import ActionRow from '@/components/list-rows/ActionRow'
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
 import PressableStyled from '@/components/shared/PressableStyled'
 import { useTranslation } from '@/hooks/useTranslation'
-import { FilteringTimeframesEnum } from '@/state/TicketsFiltersStoreProvider/TicketsFiltersStoreProvider'
+import { FilterTimeframesEnum } from '@/state/TicketsFiltersStoreProvider/TicketsFiltersStoreProvider'
 import { useTicketsFiltersStoreContext } from '@/state/TicketsFiltersStoreProvider/useTicketsFiltersStoreContext'
 import { useTicketsFiltersStoreUpdateContext } from '@/state/TicketsFiltersStoreProvider/useTicketsFiltersStoreUpdateContext'
 
@@ -26,7 +26,7 @@ const TicketsFiltersTimeframesScreen = () => {
   )
 
   const handleOptionPress = useCallback(
-    (timeframe: FilteringTimeframesEnum) => () => {
+    (timeframe: FilterTimeframesEnum) => () => {
       onPurchaseStoreUpdate({ timeframe })
       ref.current?.close()
     },
@@ -50,7 +50,7 @@ const TicketsFiltersTimeframesScreen = () => {
     >
       <BottomSheetContent>
         <View>
-          {Object.values(FilteringTimeframesEnum).map((timeframe) => (
+          {Object.values(FilterTimeframesEnum).map((timeframe) => (
             <PressableStyled key={timeframe} onPress={handleOptionPress(timeframe)}>
               <ActionRow
                 label={t(`timeframes.${timeframe}`)}

--- a/app/(app)/tickets/index.tsx
+++ b/app/(app)/tickets/index.tsx
@@ -74,11 +74,12 @@ const TicketsRoute = ({ active }: RouteProps) => {
     }
   }
 
+  // const now = useMemo(() => new Date(), [])
   const now = new Date()
   const { parkingEndFrom, parkingEndTo } = getParkingEndRange(filters.timeframe, now)
 
   const ticketsQueryOptions = ticketsInfiniteQuery({
-    parkingEndFrom: active ? now : parkingEndFrom,
+    parkingEndFrom: active ? new Date() : parkingEndFrom,
     parkingEndTo: active ? undefined : parkingEndTo,
     pageSize: 20,
     ecvs: filters.ecvs === 'all' ? undefined : filters.ecvs,

--- a/modules/backend/constants/queryOptions.ts
+++ b/modules/backend/constants/queryOptions.ts
@@ -59,16 +59,24 @@ export const ticketsInfiniteQuery = (
     isActive,
   } = options ?? {}
 
+  /*
+    FIXME all datetimes should be included in the queryKey, otherwise, data will be cached and add will show old data
+    For now, we use refetchOnMount: 'always' as a workaround - this should refetch the data as needed
+
+    The datetimes are not included now, because it causes infinite refresh loop - TODO investigate why
+   */
   return infiniteQueryOptions({
     queryKey: [
       'Tickets',
       ecvs?.join(','),
-      parkingStartFrom?.toISOString(),
-      parkingStartTo?.toISOString(),
-      // if isActive is true, parkingEndShould be the current datetime and it changes with every second, so the query keeps refetching
-      isActive ? null : parkingEndFrom?.toISOString(),
-      parkingEndTo?.toISOString(),
+      // { parkingEndFrom: parkingEndFrom?.toISOString(), parkingEndTo: parkingEndTo?.toISOString() },
+      // parkingStartFrom?.toISOString(), // TODO this is never used
+      // parkingStartTo?.toISOString(), // TODO this is never used
+      // // if isActive is true, parkingEndShould be the current datetime and it changes with every second, so the query keeps refetching
+      // isActive ? null : parkingEndFrom?.toISOString(), // TODO  This is true also for isActive=false
+      // parkingEndTo?.toISOString(), // TODO
       pageSize,
+      isActive,
     ],
     queryFn: ({ pageParam }) =>
       clientApi.ticketsControllerTicketsGetMany(
@@ -80,6 +88,7 @@ export const ticketsInfiniteQuery = (
         parkingEndFrom?.toISOString(),
         parkingEndTo?.toISOString(),
       ),
+    refetchOnMount: 'always', // TODO - used as a workaround until all datetimes are part of the queryKey
     initialPageParam: 1,
     getNextPageParam: (lastPage) => nextPageParam(lastPage.data.paginationInfo),
   })

--- a/modules/backend/hooks/usePrefetchOnAppStart.tsx
+++ b/modules/backend/hooks/usePrefetchOnAppStart.tsx
@@ -2,14 +2,12 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect } from 'react'
 import { InteractionManager } from 'react-native'
 
-import { useLocale } from '@/hooks/useTranslation'
 import { clientApi } from '@/modules/backend/client-api'
-import { announcementsOptions, visitorCardsOptions } from '@/modules/backend/constants/queryOptions'
+import { visitorCardsOptions } from '@/modules/backend/constants/queryOptions'
 import { getAccessToken } from '@/modules/cognito/utils'
 
 export const usePrefetchOnAppStart = () => {
   const queryClient = useQueryClient()
-  const locale = useLocale()
 
   const prefetch = useCallback(async () => {
     const token = await getAccessToken()
@@ -21,7 +19,7 @@ export const usePrefetchOnAppStart = () => {
 
     try {
       /* Define and prefetch standard queries */
-      const queries = [visitorCardsOptions(), announcementsOptions(locale)]
+      const queries = [visitorCardsOptions()] // , announcementsOptions(locale)
 
       // refresh verified emails before prefetching visitor cards
       await clientApi.verifiedEmailsControllerRefreshVerifiedEmail(true)
@@ -33,7 +31,7 @@ export const usePrefetchOnAppStart = () => {
     } catch (error) {
       console.log(error)
     }
-  }, [locale, queryClient])
+  }, [queryClient]) // add locale when adding announcementsOptions
 
   useEffect(() => {
     InteractionManager.runAfterInteractions(() => prefetch())

--- a/state/TicketsFiltersStoreProvider/TicketsFiltersStoreProvider.tsx
+++ b/state/TicketsFiltersStoreProvider/TicketsFiltersStoreProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, PropsWithChildren, useCallback, useState } from 'react'
 
-export enum FilteringTimeframesEnum {
+export enum FilterTimeframesEnum {
   thisMonth = 'thisMonth',
   lastMonth = 'lastMonth',
   thisYear = 'thisYear',
@@ -9,7 +9,7 @@ export enum FilteringTimeframesEnum {
 }
 
 interface TicketsFiltersStoreContextProps {
-  timeframe: FilteringTimeframesEnum | null
+  timeframe: FilterTimeframesEnum | null
   ecvs: string[] | 'all'
 }
 
@@ -23,7 +23,7 @@ export const TicketsFiltersStoreUpdateContext = createContext<
 >(null)
 
 export const defaultTicketsFiltersStoreContextValues: TicketsFiltersStoreContextProps = {
-  timeframe: FilteringTimeframesEnum.thisYear,
+  timeframe: FilterTimeframesEnum.thisYear,
   ecvs: 'all',
 }
 

--- a/utils/getParkingEndRange.ts
+++ b/utils/getParkingEndRange.ts
@@ -1,30 +1,31 @@
-import { FilteringTimeframesEnum } from '@/state/TicketsFiltersStoreProvider/TicketsFiltersStoreProvider'
+import { FilterTimeframesEnum } from '@/state/TicketsFiltersStoreProvider/TicketsFiltersStoreProvider'
 
-export const transformTimeframeToFromTo = (
-  timeframe: FilteringTimeframesEnum | null,
-  now: Date,
-) => {
+export const getParkingEndRange = (timeframe: FilterTimeframesEnum | null, now: Date) => {
   switch (timeframe) {
-    case FilteringTimeframesEnum.thisMonth:
+    case FilterTimeframesEnum.thisMonth:
       return {
         parkingEndFrom: new Date(now.getFullYear(), now.getMonth(), 1),
         parkingEndTo: now,
       }
-    case FilteringTimeframesEnum.lastMonth:
+
+    case FilterTimeframesEnum.lastMonth:
       return {
         parkingEndFrom: new Date(now.getFullYear(), now.getMonth() - 1, 1),
         parkingEndTo: new Date(now.getFullYear(), now.getMonth(), 0),
       }
-    case FilteringTimeframesEnum.thisYear:
+
+    case FilterTimeframesEnum.thisYear:
       return {
         parkingEndFrom: new Date(now.getFullYear(), 0),
         parkingEndTo: now,
       }
-    case FilteringTimeframesEnum.lastYear:
+
+    case FilterTimeframesEnum.lastYear:
       return {
         parkingEndFrom: new Date(now.getFullYear() - 1, 0),
         parkingEndTo: new Date(now.getFullYear(), -1, 31),
       }
+
     default:
       return {
         parkingEndFrom: now,


### PR DESCRIPTION
- remove `useMemo` from `now` date
- use better function names
- temporarily remove all datetimes from `queryKey` - because if some of them is not in `useMemo`, it causes infinite refetch loop
- as a potential workaround, we use `refetchOnMount: 'always'`

TODO
- investigate more why infinite refetch loop happens