### PR TITLE
#505 Show loading spinner as an overlay over content in WebView

### DIFF
--- a/app/(app)/(purchase-and-payment)/purchase/payment.tsx
+++ b/app/(app)/(purchase-and-payment)/purchase/payment.tsx
@@ -74,27 +74,30 @@ const PaymentScreen = () => {
     // TODO investigate more (same issue is in about/webview.tsx)
     // WebView crashes on Android in some cases, disabling animation helps
     // https://github.com/react-native-webview/react-native-webview/issues/3052#issuecomment-1635698194
-    <ScreenView
-      title={t('titlePayment')}
-      // options={{ animation: Platform.OS === 'android' ? 'none' : undefined }}
-    >
-      {isLoaded ? null : <LoadingScreen />}
+    <>
+      <ScreenView
+        title={t('titlePayment')}
+        // options={{ animation: Platform.OS === 'android' ? 'none' : undefined }}
+      >
+        <WebView
+          ref={webviewRef}
+          onError={redirectToPurchaseResult}
+          source={{ uri: paymentUrlDecoded }}
+          onLoad={() => setIsLoaded(true)}
+          className={cn('flex-1', { hidden: !isLoaded })}
+          onNavigationStateChange={(e) => {
+            // if user navigates by clicking link to invalid link, stop loading and go back to previous page (gateway)
+            if (invalidPaymentGatewayLinks.some((url) => e.url.includes(url))) {
+              webviewRef.current?.stopLoading()
+              webviewRef.current?.goBack()
+            }
+          }}
+        />
+      </ScreenView>
 
-      <WebView
-        ref={webviewRef}
-        onError={redirectToPurchaseResult}
-        source={{ uri: paymentUrlDecoded }}
-        onLoad={() => setIsLoaded(true)}
-        className={cn('flex-1', { hidden: !isLoaded })}
-        onNavigationStateChange={(e) => {
-          // if user navigates by clicking link to invalid link, stop loading and go back to previous page (gateway)
-          if (invalidPaymentGatewayLinks.some((url) => e.url.includes(url))) {
-            webviewRef.current?.stopLoading()
-            webviewRef.current?.goBack()
-          }
-        }}
-      />
-    </ScreenView>
+      {/* Display loading overlay until WebView is fully loaded */}
+      {isLoaded ? null : <LoadingScreen className="absolute h-full w-full bg-white/50" />}
+    </>
   )
 }
 

--- a/app/(app)/about/webview.tsx
+++ b/app/(app)/about/webview.tsx
@@ -28,18 +28,21 @@ const Page = () => {
   }
 
   return (
-    // TODO investigate more (same issue is in purchase/payment.tsx)
-    // WebView crashes on Android in some cases, disabling animation helps
-    // https://github.com/react-native-webview/react-native-webview/issues/3052#issuecomment-1635698194
-    <ScreenView options={{ animation: Platform.OS === 'android' ? 'none' : undefined }}>
-      {isLoaded ? null : <LoadingScreen />}
+    // TODO investigate more (same issue is in purchase/payment.tsx) // WebView crashes on Android
+    // in some cases, disabling animation helps //
+    //   https://github.com/react-native-webview/react-native-webview/issues/3052#issuecomment-1635698194
+    <>
+      <ScreenView options={{ animation: Platform.OS === 'android' ? 'none' : undefined }}>
+        <WebView
+          source={{ uri: uriDecoded }}
+          onLoad={() => setIsLoaded(true)}
+          className={cn('flex-1', { hidden: !isLoaded })}
+        />
+      </ScreenView>
 
-      <WebView
-        source={{ uri: uriDecoded }}
-        onLoad={() => setIsLoaded(true)}
-        className={cn('flex-1', { hidden: !isLoaded })}
-      />
-    </ScreenView>
+      {/* Display loading overlay until WebView is fully loaded */}
+      {isLoaded ? null : <LoadingScreen className="absolute h-full w-full bg-white/50" />}
+    </>
   )
 }
 


### PR DESCRIPTION
- show spinner as an overlay above webview content

The reason is, that there is a little moment until `isLoaded` state changes, so both the spinner and the webview are displayed at the same time for this moment. Before, the spinner was above the webview, what caused a content jump just after the webview is loaded.
Now, instead of the jump, content will be under the loading overlay for a fraction of time.

Before:
![image](https://github.com/bratislava/paas-mpa/assets/19418224/5fb691cd-82a2-4c14-9515-ab663df21600)

After:
![image](https://github.com/bratislava/paas-mpa/assets/19418224/1594827b-ad99-417b-a897-92990e86a3ba)
