### PR TITLE
dark theme datepicker removal

### DIFF
--- a/components/controls/date-time/DateTimePicker.tsx
+++ b/components/controls/date-time/DateTimePicker.tsx
@@ -43,6 +43,7 @@ const DateTimePicker = ({ onConfirm, onClose, initialValue, minimumDate }: Props
         is24hourSource="locale"
         modal
         open
+        theme="light"
         title={t('DateTimePicker.selectDate')}
         cancelText={t('DateTimePicker.cancel')}
         confirmText={t('DateTimePicker.confirm')}


### PR DESCRIPTION
dark theme removal in datepicker (closes #417)
<img width="361" alt="Screenshot 2024-06-11 at 10 22 31" src="https://github.com/bratislava/paas-mpa/assets/61841194/009dfde9-3349-4683-9c24-91a9027de124">

<img width="344" alt="Screenshot 2024-06-11 at 10 22 19" src="https://github.com/bratislava/paas-mpa/assets/61841194/6414ef44-d5e3-41b9-806a-0cba85a5295e">
