### PR TITLE
#527: Fix onboarding hidden text on small screens

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -14,7 +14,7 @@ import {
   ImageWelcome,
 } from '@/assets/onboarding-slides'
 import ContinueButton from '@/components/navigation/ContinueButton'
-import MarketingTabBar from '@/components/navigation/MarketingTabBar'
+import OnboardingTabBar from '@/components/navigation/OnboardingTabBar'
 import InfoSlide from '@/components/screen-layout/InfoSlide'
 import Button from '@/components/shared/Button'
 import FlexRow from '@/components/shared/FlexRow'
@@ -33,7 +33,7 @@ export type OnboardingRouteKey =
   | 'visitorsFree'
   | 'bonusCard'
 
-type MarketingSliderRouteProps = {
+type OnboardingSliderRouteProps = {
   slide: OnboardingRouteKey
 }
 
@@ -42,7 +42,7 @@ type OnboardingRoute = {
   accessibilityLabel: string
 }
 
-const MarketingSliderRoute = ({ slide }: MarketingSliderRouteProps) => {
+const OnboardingSliderRoute = ({ slide }: OnboardingSliderRouteProps) => {
   const locale = useLocale()
 
   const translationsMap = useOnboardingTranslation()
@@ -77,7 +77,7 @@ const renderScene = ({
   route,
 }: SceneRendererProps & {
   route: OnboardingRoute
-}) => <MarketingSliderRoute slide={route.key} />
+}) => <OnboardingSliderRoute slide={route.key} />
 
 const OnboardingScreen = () => {
   const { t } = useTranslation()
@@ -154,7 +154,7 @@ const OnboardingScreen = () => {
         }}
         onIndexChange={setIndex}
         initialLayout={{ width: layout.width }}
-        renderTabBar={(props) => <MarketingTabBar {...props} />}
+        renderTabBar={(props) => <OnboardingTabBar {...props} />}
         tabBarPosition="bottom"
         className="pb-5"
       />

--- a/components/navigation/OnboardingTabBar.tsx
+++ b/components/navigation/OnboardingTabBar.tsx
@@ -9,7 +9,7 @@ import {
 import PressableStyled from '@/components/shared/PressableStyled'
 import { cn } from '@/utils/cn'
 
-const MarketingTabBar = (
+const OnboardingTabBar = (
   props: SceneRendererProps & { navigationState: NavigationState<Route> },
 ) => {
   return (
@@ -44,4 +44,4 @@ const styles = StyleSheet.create({
   style: { backgroundColor: 'transparent' },
 })
 
-export default MarketingTabBar
+export default OnboardingTabBar

--- a/components/screen-layout/InfoSlide.tsx
+++ b/components/screen-layout/InfoSlide.tsx
@@ -16,7 +16,11 @@ const InfoSlide = ({ title, text, SvgImage, className }: Props) => {
   return (
     <View className={cn('min-h-0 flex-1', className)}>
       {/* TODO if image gets deformed by scaling, try to use preserveAspectRatio */}
-      <View className="relative aspect-square">
+      {/* Use "max-h-[100vw] shrink" to:
+          - prevent the image to grow its height more that its width (= square)
+          - shrink the image height on smaller screens to prevent text to hide unintentionally
+      */}
+      <View className="relative max-h-[100vw] shrink">
         <SvgImage width="100%" height="100%" />
       </View>
 


### PR DESCRIPTION
Images keep the square shape if possible (if there is enough vertical space) (A),
or they shrink if there is not enough space (B).
(Borders are used just on screenshots, not in code)

A
![image](https://github.com/bratislava/paas-mpa/assets/19418224/1e4d29d7-ff77-48af-95b3-3fea719f23ef)

B
![image](https://github.com/bratislava/paas-mpa/assets/19418224/fb18049f-aaf0-443d-a4ca-a4a2ab77c288)

