### PR TITLE
#558 Add proper update links to stores

### DIFF
--- a/components/special/StoreVersionControl.tsx
+++ b/components/special/StoreVersionControl.tsx
@@ -33,11 +33,10 @@ const StoreVersionControl = () => {
   // eslint-disable-next-line unicorn/consistent-function-scoping
   const goToStore = () => {
     if (Platform.OS === 'ios') {
-      // TODO change to correct app store link
-      Linking.openURL('https://apps.apple.com/us/app/id1531373575')
+      // TODO this link should be correct, but it does not work yet, probably due to App Store search indexing
+      Linking.openURL('https://apps.apple.com/app/paas/id6457264414')
     } else {
-      // TODO change to correct play store link
-      Linking.openURL('https://play.google.com/store/apps/details?id=com.trafficnow')
+      Linking.openURL('https://play.google.com/store/apps/details?id=com.bratislava.paas')
     }
   }
 


### PR DESCRIPTION
Note that ios link does not work yet, but it's a correct link. From what I found so far, it seems that it takes time to App Store to get the link to work due to search indexing.

I would like to merge these link into the code now, not wait until the ios link works.

Android needs to be tested.