### PR TITLE
#577 Fix `parkingStart` and `parkingEnd` to be sent rounded to minutes

### DIFF
--- a/components/controls/date-time/TimeSelector.tsx
+++ b/components/controls/date-time/TimeSelector.tsx
@@ -17,6 +17,7 @@ import { formatDuration } from '@/utils/formatDuration'
  * Returns duration in seconds.
  *
  * @param date
+ * @param base
  */
 const getDuration = (date: Date, base: Date) => {
   const diff = date.getTime() - base.getTime()
@@ -30,24 +31,14 @@ type Props = {
   onValueChange: (value: number) => void
 }
 
-/**
- * Function to calculate end time from calculation base (or current time if base is not provided) and duration
- */
-const calculateEndTime = (duration: number, timeCalculationBase: number) => {
-  return new Date(timeCalculationBase + duration * 1000)
-}
-
 const TimeSelector = ({ value, timeCalculationBase, onValueChange }: Props) => {
   const { t } = useTranslation()
   const locale = useLocale()
   const [datePickerOpen, setDatePickerOpen] = useState(false)
 
-  const calculationBaseDate = new Date(timeCalculationBase || Date.now())
-
-  const validUntil = useMemo(
-    () => formatDateTime(calculateEndTime(value, timeCalculationBase || Date.now()), locale),
-    [locale, value, timeCalculationBase],
-  )
+  const baseTimeTimestamp = timeCalculationBase || Date.now()
+  const baseTimeDate = new Date(baseTimeTimestamp)
+  const endTimeDate = new Date(baseTimeTimestamp + value * 1000)
 
   /**
    * Add 15 minutes
@@ -91,7 +82,7 @@ const TimeSelector = ({ value, timeCalculationBase, onValueChange }: Props) => {
   }
 
   const handleDatePickerConfirm = (date: Date) => {
-    const duration = getDuration(date, calculationBaseDate)
+    const duration = getDuration(date, baseTimeDate)
 
     onValueChange(duration)
   }
@@ -155,14 +146,14 @@ const TimeSelector = ({ value, timeCalculationBase, onValueChange }: Props) => {
       <FlexRow>
         <Typography variant="small">{t('TimeSelector.validUntil')}</Typography>
         <PressableStyled onPress={handleDatePickerOpen}>
-          <Typography variant="small-bold">{validUntil}</Typography>
+          <Typography variant="small-bold">{formatDateTime(endTimeDate, locale)}</Typography>
         </PressableStyled>
       </FlexRow>
 
       {datePickerOpen ? (
         <DateTimePicker
-          minimumDate={calculationBaseDate}
-          initialValue={calculateEndTime(value, calculationBaseDate.getTime())}
+          minimumDate={baseTimeDate}
+          initialValue={endTimeDate}
           onClose={handleDatePickerClose}
           onConfirm={handleDatePickerConfirm}
         />

--- a/utils/createPriceRequestBody.ts
+++ b/utils/createPriceRequestBody.ts
@@ -3,7 +3,7 @@ import { MapUdrZone } from '@/modules/map/types'
 
 /**
  * Function to create price request body needed for having fresh parkingStart
- * otherwise useMemo would store old time value and it cannot be changed to new one without having infinite loop
+ * otherwise useMemo would store old time value, and it cannot be changed to new one without having infinite loop
  * @param param0 object with udr, licencePlate, duration, npk and rememberCard
  * @returns price request body
  */
@@ -20,12 +20,14 @@ export const createPriceRequestBody = ({
   npk: ParkingCardDto | null
   rememberCard?: boolean
 }) => {
-  const dateNow = Date.now()
+  // Set time to whole minutes. Otherwise, it would charge several seconds more in some cases.
+  // E.g. when buying the ticket before the paid period (in this case parkingStart has whole minutes and parkingEnd must have too)
+  const dateNow = new Date().setSeconds(0, 0)
   const parkingStart = new Date(dateNow).toISOString()
   const parkingEnd = new Date(dateNow + duration * 1000).toISOString()
 
   return {
-    npkId: npk?.identificator || undefined,
+    npkId: npk?.identificator || undefined, // TODO If `|| undefined` is intentional, please explain in comment.
     ticket: {
       udr: String(udr?.udrId) ?? '',
       ecv: licencePlate ?? '',


### PR DESCRIPTION
The main issue was with parking tickets bought before paid period, because then the paid parking start was always rounded to minutes, but parking end was not.

The main change is `const dateNow = new Date().setSeconds(0, 0)`.
Other is just cleanup.