### PR TITLE
#595 Add feedback message helptext

### DIFF
--- a/app/(app)/feedback/index.tsx
+++ b/app/(app)/feedback/index.tsx
@@ -119,6 +119,9 @@ const FeedbackScreen = () => {
             <AccessibilityField
               style={{ flex: 1 }}
               label={t('FeedbackScreen.yourMessage')}
+              helptext={
+                feedbackType === 'bug' ? t('FeedbackScreen.yourMessage.helpText') : undefined
+              }
               errorMessage={isValidMessage ? undefined : t('FeedbackScreen.yourMessageInvalid')}
             >
               <TextInput

--- a/components/shared/Field.tsx
+++ b/components/shared/Field.tsx
@@ -8,6 +8,7 @@ export type FieldProps = {
   label: string
   labelInsertArea?: ReactNode
   children: ReactNode
+  helptext?: string
   errorMessage?: string
   variant?: TypographyProps['variant']
   className?: string
@@ -20,6 +21,7 @@ const Field = ({
   children,
   labelInsertArea,
   nativeID,
+  helptext,
   errorMessage,
   variant = 'default-bold',
   style,
@@ -33,6 +35,7 @@ const Field = ({
         </Typography>
         {labelInsertArea || null}
       </View>
+      {helptext ? <Typography>{helptext}</Typography> : null}
       {children}
       {errorMessage ? <Typography className="text-negative">{errorMessage}</Typography> : null}
     </View>

--- a/translations/en.json
+++ b/translations/en.json
@@ -70,6 +70,7 @@
   "FeedbackScreen.title": "Feedback",
   "FeedbackScreen.type": "Type",
   "FeedbackScreen.yourMessage": "Your message",
+  "FeedbackScreen.yourMessage.helpText": "Describe the bug in detail (e.g., license plate number, time and place of parking, method and time of payment, etc.).",
   "FeedbackScreen.yourMessageInvalid": "Please enter a message",
   "FiltersScreen.filteringOptions.active": "Parking zone",
   "FiltersScreen.filteringOptions.branch": "Customer center",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -70,6 +70,7 @@
   "FeedbackScreen.title": "Spätná väzba",
   "FeedbackScreen.type": "Typ",
   "FeedbackScreen.yourMessage": "Vaša správa",
+  "FeedbackScreen.yourMessage.helpText": "Opíšte nám chybu detailne (napr: EČV, kedy a kde ste parkovali, spôsob a čas úhrady a podobne).",
   "FeedbackScreen.yourMessageInvalid": "Prosím, zadajte vašu správu",
   "FiltersScreen.filteringOptions.active": "Parkovacie zóny",
   "FiltersScreen.filteringOptions.branch": "Klientske miesto",


### PR DESCRIPTION
- closes #595

Note: We don't have design for helptext in figma, so we follow the pattern from Bratislava DS (helptext above the field).



![image](https://github.com/user-attachments/assets/396d9228-8757-487b-9932-d4fce64b83ec)

