### PR TITLE
#531 Temporary fix for BottomSheet to show also when ReducedMotion is on

### DIFF
--- a/app/(app)/payment-options.tsx
+++ b/app/(app)/payment-options.tsx
@@ -5,6 +5,7 @@ import {
 } from '@gorhom/bottom-sheet'
 import { useCallback, useRef, useState } from 'react'
 import { Platform, ScrollView } from 'react-native'
+import { useReducedMotion } from 'react-native-reanimated'
 
 import PaymentOptionRow from '@/components/controls/payment-methods/rows/PaymentOptionRow'
 import { PaymentOption } from '@/components/controls/payment-methods/types'
@@ -19,6 +20,7 @@ import { useTranslation } from '@/hooks/useTranslation'
 
 const Page = () => {
   const { t } = useTranslation()
+  const reducedMotion = useReducedMotion()
 
   const paymentOptions: PaymentOption[] = [
     'payment-card',
@@ -82,6 +84,7 @@ const Page = () => {
         enableDynamicSizing
         enablePanDownToClose
         backdropComponent={renderBackdrop}
+        animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
       >
         <BottomSheetContent>
           <PressableStyled onPress={handleActionSetDefault}>

--- a/app/(app)/settings/index.tsx
+++ b/app/(app)/settings/index.tsx
@@ -7,6 +7,7 @@ import { useMutation } from '@tanstack/react-query'
 import { deleteUser } from 'aws-amplify/auth'
 import { useCallback, useRef } from 'react'
 import { ScrollView } from 'react-native'
+import { useReducedMotion } from 'react-native-reanimated'
 
 import LanguageSelectField from '@/components/controls/LanguageSelectField'
 import NotificationSettings from '@/components/controls/notifications/NotificationSettings'
@@ -29,6 +30,7 @@ const SettingsPage = () => {
 
   const { isModalVisible, openModal, closeModal, toggleModal } = useModal()
   const bottomSheetRef = useRef<BottomSheetModal>(null)
+  const reducedMotion = useReducedMotion()
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
@@ -86,6 +88,7 @@ const SettingsPage = () => {
         enableDynamicSizing
         enablePanDownToClose
         backdropComponent={renderBackdrop}
+        animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
       >
         <BottomSheetContent className="min-h-[80px]">
           <PressableStyled onPress={handleActionDelete}>

--- a/app/(app)/vehicles/index.tsx
+++ b/app/(app)/vehicles/index.tsx
@@ -6,6 +6,7 @@ import {
 import { Link, router } from 'expo-router'
 import { useCallback, useRef, useState } from 'react'
 import { SectionList, View } from 'react-native'
+import { useReducedMotion } from 'react-native-reanimated'
 
 import NoVehicles from '@/components/controls/vehicles/NoVehicles'
 import SkeletonVehicleRow from '@/components/controls/vehicles/SkeletonVehicleRow'
@@ -32,6 +33,7 @@ import { isDefined } from '@/utils/isDefined'
 const VehiclesScreen = () => {
   const { t } = useTranslation()
   const { isModalVisible, openModal, closeModal, toggleModal } = useModal()
+  const reducedMotion = useReducedMotion()
 
   const { vehicles, deleteVehicle, defaultVehicle, setDefaultVehicle, isInitialLoading } =
     useVehiclesStoreContext()
@@ -150,6 +152,7 @@ const VehiclesScreen = () => {
         enableDynamicSizing
         enablePanDownToClose
         backdropComponent={renderBackdrop}
+        animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
       >
         <BottomSheetContent>
           {activeVehicleId === defaultVehicle?.id ? null : (

--- a/components/parking-cards/EmailsBottomSheet.tsx
+++ b/components/parking-cards/EmailsBottomSheet.tsx
@@ -6,6 +6,7 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { router, useLocalSearchParams } from 'expo-router'
 import { forwardRef, useCallback, useRef, useState } from 'react'
+import { useReducedMotion } from 'react-native-reanimated'
 
 import { ParkingCardsLocalSearchParams } from '@/app/(app)/parking-cards/[email]'
 import ActionRow from '@/components/list-rows/ActionRow'
@@ -21,6 +22,7 @@ import { verifiedEmailsInfiniteOptions } from '@/modules/backend/constants/query
 const EmailsBottomSheet = forwardRef<BottomSheetModal>((props, ref) => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const reducedMotion = useReducedMotion()
 
   const localRef = useRef<BottomSheetModal>(null)
   const refSetter = useMultipleRefsSetter(localRef, ref)
@@ -79,6 +81,7 @@ const EmailsBottomSheet = forwardRef<BottomSheetModal>((props, ref) => {
         enableDynamicSizing
         enablePanDownToClose
         backdropComponent={renderBackdrop}
+        animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
       >
         <BottomSheetContent>
           <PressableStyled onPress={handleModalOpen}>

--- a/components/tickets/TicketsHistoryBottomSheet.tsx
+++ b/components/tickets/TicketsHistoryBottomSheet.tsx
@@ -6,6 +6,7 @@ import {
 import { useMutation } from '@tanstack/react-query'
 import React, { forwardRef, useCallback, useRef } from 'react'
 import { Linking, View } from 'react-native'
+import { useReducedMotion } from 'react-native-reanimated'
 
 import ActionRow from '@/components/list-rows/ActionRow'
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
@@ -20,6 +21,7 @@ type Props = {
 
 const TicketsHistoryBottomSheet = forwardRef<BottomSheetModal, Props>(({ activeId }, ref) => {
   const { t } = useTranslation()
+  const reducedMotion = useReducedMotion()
 
   const localRef = useRef<BottomSheetModal>(null)
   const refSetter = useMultipleRefsSetter(localRef, ref)
@@ -52,6 +54,7 @@ const TicketsHistoryBottomSheet = forwardRef<BottomSheetModal, Props>(({ activeI
       enableDynamicSizing
       enablePanDownToClose
       backdropComponent={renderBackdrop}
+      animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
     >
       <BottomSheetContent>
         {downloadReceiptMutation.isPending ? (


### PR DESCRIPTION
- fix `BottomSheet` didn't appear on three-dots button press in Vehicles screen and Ticket History screen
- closes #531 
- closes bratislava/paas-mpa-private#1

The issue is probably caused when ReducedMotion is enabled. Note that `ReducedMotion` is also enabled when battery is <10% (on ios).

Quick explanation of the problem and the fix:
With newer version of `react-native-reanimated` that included support for `ReducedMotion`, `BottomSheet` has problem to appear if `ReducedMotion` is enabled. It's supposed to be fixed in BottomSheet version 4.6.3 (latests at this time), but [people write](https://github.com/gorhom/react-native-bottom-sheet/issues/1560#issuecomment-2183549675) it's still buggy, and the upgrade to newer version should be done with proper testing, not as quick fix.
So I decided to use [the hot-fix](https://github.com/gorhom/react-native-bottom-sheet/issues/1560#issuecomment-1750466864): disable `animateOnMount` when `ReducedMotion` is used.
People also mentioned problem with this hot-fix with `.dismiss()`, but we use `.close()` instead of `.dismiss()` and it worked okay when I tested it.

Tested locally on iphone 15 on physical device with ReducedMotion enabled ✅ 

See more in the issue thread: https://github.com/gorhom/react-native-bottom-sheet/issues/1560