### PR TITLE
#586 Fix double map recenter when GPS enabled

### DIFF
--- a/modules/map/hooks/useLocation.ts
+++ b/modules/map/hooks/useLocation.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { useLocationPermission } from '@/modules/map/hooks/useLocationPermission'
 
-// TOTO refactor
+// TODO refactor
 export const useLocation = () => {
   const [location, setLocation] = useState<Location.LocationObject | null>(null)
   const { locationPermissionStatus } = useLocationPermission()

--- a/modules/map/hooks/useLocation.ts
+++ b/modules/map/hooks/useLocation.ts
@@ -3,30 +3,26 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { useLocationPermission } from '@/modules/map/hooks/useLocationPermission'
 
+// TOTO refactor
 export const useLocation = () => {
   const [location, setLocation] = useState<Location.LocationObject | null>(null)
   const { locationPermissionStatus } = useLocationPermission()
-
-  const getCurrentPosition = useCallback(async () => {
-    const currentPosition = await Location.getCurrentPositionAsync()
-    setLocation(currentPosition)
-  }, [])
 
   const getLocation = useCallback(async () => {
     if (locationPermissionStatus !== Location.PermissionStatus.GRANTED) return
 
     const lastKnownPosition = await Location.getLastKnownPositionAsync()
     setLocation(lastKnownPosition)
-    getCurrentPosition()
-  }, [locationPermissionStatus, getCurrentPosition])
+
+    // Request the current position for next-time use.
+    // It should be used on next visit of Map screen or when GPS button is pressed (if already available)
+    await Location.getCurrentPositionAsync()
+  }, [locationPermissionStatus])
 
   // TODO handle error
   useEffect(() => {
-    getLocation().catch((error) => {
-      console.warn(error)
-      setLocation(null)
-    })
+    getLocation()
   }, [getLocation])
 
-  return [location, getLocation] as const
+  return [location] as const
 }

--- a/modules/map/hooks/useLocationPermission.ts
+++ b/modules/map/hooks/useLocationPermission.ts
@@ -3,13 +3,8 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { useAppFocusEffect } from '@/hooks/useAppFocusEffect'
 
-type Options =
-  | {
-      autoAsk?: boolean
-    }
-  | undefined
-
-export const useLocationPermission = ({ autoAsk }: Options = {}) => {
+// TODO refactor
+export const useLocationPermission = () => {
   const [permissionStatus, setPermissionStatus] = useState<Location.PermissionStatus>(
     Location.PermissionStatus.UNDETERMINED,
   )
@@ -45,14 +40,6 @@ export const useLocationPermission = ({ autoAsk }: Options = {}) => {
       setPermissionStatus(currentStatus)
     }
   }, [doNotAskAgain])
-
-  useEffect(() => {
-    if (autoAsk) {
-      getPermission().catch((error) => {
-        console.warn(error)
-      })
-    }
-  }, [getPermission, autoAsk])
 
   return { locationPermissionStatus: permissionStatus, getLocationPermission: getPermission }
 }


### PR DESCRIPTION
- do not recenter after `getCurrentPositionAsync` is obtained because it caused second recenter even when user moved the map pin - instead, the new position will be used just when user presses the GPS button
- cleanup unused code

I tried to test it on physical device (iphone 15) and it seems to work. Further testing with physical device in terrain could be useful.