### PR TITLE
#594 Add infobanner on android to check notifications permissions

### DIFF
--- a/components/controls/notifications/NotificationSettings.tsx
+++ b/components/controls/notifications/NotificationSettings.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
-import { Linking } from 'react-native'
+import { Linking, Platform } from 'react-native'
 
 import NotificationControl from '@/components/controls/notifications/NotificationControl'
 import LoadingScreen from '@/components/screen-layout/LoadingScreen'
@@ -115,6 +115,19 @@ const NotificationSettings = () => {
           <Typography>{t('Settings.notificationsDisabled')}</Typography>
           <PressableStyled className="inline-flex" onPress={() => Linking.openSettings()}>
             <Typography variant="default-bold">{t('Settings.notificationButtonText')}</Typography>
+          </PressableStyled>
+        </Panel>
+      ) : null}
+
+      {/* Temporarily show info to user to double-check notification permission. */}
+      {/* Used until we use react-native-notifications because @react-native-firebase/messaging works only on ios */}
+      {Platform.OS === 'android' ? (
+        <Panel className="my-2 bg-warning-light px-5">
+          <Typography>{t('Settings.notificationsWarningAndroid')}</Typography>
+          <PressableStyled className="inline-flex" onPress={() => Linking.openSettings()}>
+            <Typography variant="default-bold">
+              {t('Settings.notificationsWarningAndroid.buttonText')}
+            </Typography>
           </PressableStyled>
         </Panel>
       ) : null}

--- a/translations/en.json
+++ b/translations/en.json
@@ -243,6 +243,8 @@
   "Settings.language": "Language",
   "Settings.notificationButtonText": "Enable notifications",
   "Settings.notificationsDisabled": "Notifications are not enabled on your device.",
+  "Settings.notificationsWarningAndroid": "To ensure notifications work properly, please verify that PAAS has notification permissions enabled.",
+  "Settings.notificationsWarningAndroid.buttonText": "Open settings",
   "Settings.openContextMenu": "Open context menu",
   "Settings.pushNotifications": "Push notifications",
   "Settings.title": "Settings",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -243,6 +243,8 @@
   "Settings.language": "Jazyk",
   "Settings.notificationButtonText": "Povoliť notifikácie",
   "Settings.notificationsDisabled": "Notifikácie nie sú povolené na tomto zariadení.",
+  "Settings.notificationsWarningAndroid": "Pre správne fungovanie sa uistite, že aplikácia PAAS má povolenie na posielanie notifikácií.",
+  "Settings.notificationsWarningAndroid.buttonText": "Otvoriť nastavenia",
   "Settings.openContextMenu": "Otvoriť menu",
   "Settings.pushNotifications": "Push notifikácie",
   "Settings.title": "Nastavenia",


### PR DESCRIPTION
Temporarily show infobanner, until we implement `react-native-notifications`.

![image](https://github.com/user-attachments/assets/8917ab79-4ba6-4999-a1e2-1da65a389433)

![image](https://github.com/user-attachments/assets/43cad74a-bdba-488d-a2a2-9210cc68ca84)
