### PR TITLE
#612 Fix BottomSHeets when Reduced Motion enabled

### DIFF
--- a/app/(app)/tickets/filters/timeframes.tsx
+++ b/app/(app)/tickets/filters/timeframes.tsx
@@ -1,7 +1,8 @@
 import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps } from '@gorhom/bottom-sheet'
 import { router } from 'expo-router'
-import { useCallback, useRef } from 'react'
+import { Fragment, useCallback, useRef } from 'react'
 import { View } from 'react-native'
+import { useReducedMotion } from 'react-native-reanimated'
 
 import ActionRow from '@/components/list-rows/ActionRow'
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
@@ -12,7 +13,10 @@ import { FilterTimeframesEnum } from '@/state/TicketsFiltersStoreProvider/Ticket
 import { useTicketsFiltersStoreContext } from '@/state/TicketsFiltersStoreProvider/useTicketsFiltersStoreContext'
 import { useTicketsFiltersStoreUpdateContext } from '@/state/TicketsFiltersStoreProvider/useTicketsFiltersStoreUpdateContext'
 
+// TODO refactor from screen to component, because it return only BottomSheet
 const TicketsFiltersTimeframesScreen = () => {
+  const reducedMotion = useReducedMotion()
+
   const snapPoints = [300]
   const ref = useRef<BottomSheet>(null)
   const { timeframe: selectedTimeframe } = useTicketsFiltersStoreContext()
@@ -48,20 +52,21 @@ const TicketsFiltersTimeframesScreen = () => {
       snapPoints={snapPoints}
       onChange={handleSheetChanges}
       enablePanDownToClose
+      animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
     >
       <BottomSheetContent>
         <View>
           {Object.values(FilterTimeframesEnum).map((timeframe, index) => (
-            <>
-              {index > 0 && <Divider key={`divider-${timeframe}`} />}
+            <Fragment key={timeframe}>
+              {index > 0 && <Divider />}
 
-              <PressableStyled key={timeframe} onPress={handleOptionPress(timeframe)}>
+              <PressableStyled onPress={handleOptionPress(timeframe)}>
                 <ActionRow
                   label={translationMap[timeframe]}
                   endIcon={timeframe === selectedTimeframe ? 'check-circle' : undefined}
                 />
               </PressableStyled>
-            </>
+            </Fragment>
           ))}
         </View>
       </BottomSheetContent>

--- a/components/map/MapLocationBottomSheet.tsx
+++ b/components/map/MapLocationBottomSheet.tsx
@@ -2,6 +2,7 @@ import BottomSheet from '@gorhom/bottom-sheet'
 import * as Location from 'expo-location'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Linking, Platform, View } from 'react-native'
+import { useReducedMotion } from 'react-native-reanimated'
 
 import AvatarCircleLocationOff from '@/components/info/AvatarCircleLocationOff'
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
@@ -15,6 +16,8 @@ import { useLocationPermission } from '@/modules/map/hooks/useLocationPermission
 const MapLocationBottomSheet = () => {
   const { t } = useTranslation()
   const ref = useRef<BottomSheet>(null)
+  const reducedMotion = useReducedMotion()
+
   const { locationPermissionStatus, getLocationPermission } = useLocationPermission()
   const [isLocationOn, setIsLocationOn] = useState(true)
 
@@ -74,6 +77,7 @@ const MapLocationBottomSheet = () => {
       handleComponent={BottomSheetHandleWithShadow}
       enablePanDownToClose
       enableDynamicSizing
+      animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
     >
       <BottomSheetContent>
         <ContentWithAvatar

--- a/components/map/MapPointBottomSheet.tsx
+++ b/components/map/MapPointBottomSheet.tsx
@@ -1,6 +1,7 @@
 import BottomSheet, { BottomSheetFooterProps, BottomSheetScrollView } from '@gorhom/bottom-sheet'
 import { forwardRef, Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { LayoutAnimation, View } from 'react-native'
+import { useReducedMotion } from 'react-native-reanimated'
 
 import NavigateBottomSheetFooter from '@/components/map/NavigateBottomSheetFooter'
 import BottomSheetHandleWithShadow from '@/components/screen-layout/BottomSheet/BottomSheetHandleWithShadow'
@@ -43,6 +44,7 @@ const MapPointBottomSheet = forwardRef<BottomSheet, Props>(({ point }, ref) => {
   const { t } = useTranslation()
   const locale = useLocale()
   const [footerHeight, setFooterHeight] = useState(0)
+  const reducedMotion = useReducedMotion()
 
   // TODO translation
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -129,6 +131,7 @@ const MapPointBottomSheet = forwardRef<BottomSheet, Props>(({ point }, ref) => {
       snapPoints={snapPoints}
       footerComponent={renderFooter}
       handleComponent={BottomSheetHandleWithShadow}
+      animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
     >
       <View className="flex-1">
         <View className="flex-row justify-center border-b border-b-divider pb-3">

--- a/components/tickets/PurchaseBottomSheet.tsx
+++ b/components/tickets/PurchaseBottomSheet.tsx
@@ -1,6 +1,7 @@
 import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet'
 import { forwardRef, useMemo } from 'react'
 import { View } from 'react-native'
+import { useReducedMotion } from 'react-native-reanimated'
 
 import BottomSheetHandleWithShadow, {
   HANDLE_HEIGHT,
@@ -29,6 +30,7 @@ const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(
     const { udr } = usePurchaseStoreContext()
 
     const snapPoints = useMemo(() => [HANDLE_HEIGHT], [])
+    const reducedMotion = useReducedMotion()
 
     const durationFromPriceDate = getDurationFromPriceData(priceData)
 
@@ -39,6 +41,7 @@ const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(
         bottomInset={purchaseButtonContainerHeight}
         snapPoints={snapPoints}
         handleComponent={BottomSheetHandleWithShadow}
+        animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
       >
         {/**
          * Better approach for zero height bottom sheet: https://github.com/gorhom/react-native-bottom-sheet/issues/1573


### PR DESCRIPTION
- add the same hotfix to all `BottomSheet`s (before it was added only to `BottomSheetModal`s) as in #604 
- move `key` to fragment in `timeframes` bottom sheet, because it showed error "duplicate key" 🤷 