### PR TITLE
#650 resolve issue with top attachment that disapears on rerender

### DIFF
--- a/app/(app)/payment-options.tsx
+++ b/app/(app)/payment-options.tsx
@@ -84,7 +84,7 @@ const Page = () => {
         enableDynamicSizing
         enablePanDownToClose
         backdropComponent={renderBackdrop}
-        animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
+        animateOnMount={!reducedMotion}
       >
         <BottomSheetContent>
           <PressableStyled onPress={handleActionSetDefault}>

--- a/app/(app)/settings/index.tsx
+++ b/app/(app)/settings/index.tsx
@@ -88,7 +88,7 @@ const SettingsPage = () => {
         enableDynamicSizing
         enablePanDownToClose
         backdropComponent={renderBackdrop}
-        animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
+        animateOnMount={!reducedMotion}
       >
         <BottomSheetContent className="min-h-[80px]">
           <PressableStyled onPress={handleActionDelete}>

--- a/app/(app)/tickets/filters/timeframes.tsx
+++ b/app/(app)/tickets/filters/timeframes.tsx
@@ -17,7 +17,6 @@ import { useTicketsFiltersStoreUpdateContext } from '@/state/TicketsFiltersStore
 const TicketsFiltersTimeframesScreen = () => {
   const reducedMotion = useReducedMotion()
 
-  const snapPoints = [300]
   const ref = useRef<BottomSheet>(null)
   const { timeframe: selectedTimeframe } = useTicketsFiltersStoreContext()
   const onPurchaseStoreUpdate = useTicketsFiltersStoreUpdateContext()
@@ -48,11 +47,10 @@ const TicketsFiltersTimeframesScreen = () => {
     <BottomSheet
       ref={ref}
       backdropComponent={renderBackdrop}
-      index={0}
-      snapPoints={snapPoints}
       onChange={handleSheetChanges}
+      enableDynamicSizing
       enablePanDownToClose
-      animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
+      animateOnMount={!reducedMotion}
     >
       <BottomSheetContent>
         <View>

--- a/app/(app)/vehicles/index.tsx
+++ b/app/(app)/vehicles/index.tsx
@@ -152,7 +152,7 @@ const VehiclesScreen = () => {
         enableDynamicSizing
         enablePanDownToClose
         backdropComponent={renderBackdrop}
-        animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
+        animateOnMount={!reducedMotion}
       >
         <BottomSheetContent>
           {activeVehicleId === defaultVehicle?.id ? null : (

--- a/components/map/MapLocationBottomSheet.tsx
+++ b/components/map/MapLocationBottomSheet.tsx
@@ -77,7 +77,7 @@ const MapLocationBottomSheet = () => {
       handleComponent={BottomSheetHandleWithShadow}
       enablePanDownToClose
       enableDynamicSizing
-      animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
+      animateOnMount={!reducedMotion}
     >
       <BottomSheetContent>
         <ContentWithAvatar

--- a/components/map/MapPointBottomSheet.tsx
+++ b/components/map/MapPointBottomSheet.tsx
@@ -131,7 +131,7 @@ const MapPointBottomSheet = forwardRef<BottomSheet, Props>(({ point }, ref) => {
       snapPoints={snapPoints}
       footerComponent={renderFooter}
       handleComponent={BottomSheetHandleWithShadow}
-      animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
+      animateOnMount={!reducedMotion}
     >
       <View className="flex-1">
         <View className="flex-row justify-center border-b border-b-divider pb-3">

--- a/components/parking-cards/EmailsBottomSheet.tsx
+++ b/components/parking-cards/EmailsBottomSheet.tsx
@@ -81,7 +81,7 @@ const EmailsBottomSheet = forwardRef<BottomSheetModal>((props, ref) => {
         enableDynamicSizing
         enablePanDownToClose
         backdropComponent={renderBackdrop}
-        animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
+        animateOnMount={!reducedMotion}
       >
         <BottomSheetContent>
           <PressableStyled onPress={handleModalOpen}>

--- a/components/screen-layout/BottomSheet/BottomSheetTopAttachment.tsx
+++ b/components/screen-layout/BottomSheet/BottomSheetTopAttachment.tsx
@@ -1,6 +1,6 @@
-import { PropsWithChildren, useCallback, useState } from 'react'
-import { LayoutChangeEvent, useWindowDimensions } from 'react-native'
-import Animated, { interpolate, SharedValue, useAnimatedStyle } from 'react-native-reanimated'
+import { PropsWithChildren, useCallback } from 'react'
+import { LayoutChangeEvent } from 'react-native'
+import Animated, { SharedValue, useAnimatedStyle, useSharedValue } from 'react-native-reanimated'
 
 export type BottomSheetTopAttachmentProps = PropsWithChildren & {
   animatedPosition: SharedValue<number>
@@ -10,19 +10,18 @@ const BottomSheetTopAttachment = ({
   children,
   animatedPosition,
 }: BottomSheetTopAttachmentProps) => {
-  const { height: screenHeight } = useWindowDimensions()
-  const [height, setHeight] = useState(0)
-  const animatedStyles = useAnimatedStyle(() => {
-    const translateY = interpolate(animatedPosition.value, [0, screenHeight], [0, screenHeight])
+  const sharedHeight = useSharedValue(0)
 
-    return {
-      transform: [{ translateY: -height }, { translateY }],
-    }
-  })
+  const animatedStyles = useAnimatedStyle(() => ({
+    transform: [{ translateY: -sharedHeight.value }, { translateY: animatedPosition.value }],
+  }))
 
-  const handleLayout = useCallback((event: LayoutChangeEvent) => {
-    setHeight(event.nativeEvent.layout.height)
-  }, [])
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      sharedHeight.value = event.nativeEvent.layout.height
+    },
+    [sharedHeight],
+  )
 
   return (
     <Animated.View

--- a/components/tickets/PurchaseBottomSheet.tsx
+++ b/components/tickets/PurchaseBottomSheet.tsx
@@ -41,7 +41,7 @@ const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(
         bottomInset={purchaseButtonContainerHeight}
         snapPoints={snapPoints}
         handleComponent={BottomSheetHandleWithShadow}
-        animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
+        animateOnMount={!reducedMotion}
       >
         {/**
          * Better approach for zero height bottom sheet: https://github.com/gorhom/react-native-bottom-sheet/issues/1573

--- a/components/tickets/TicketsHistoryBottomSheet.tsx
+++ b/components/tickets/TicketsHistoryBottomSheet.tsx
@@ -54,7 +54,7 @@ const TicketsHistoryBottomSheet = forwardRef<BottomSheetModal, Props>(({ activeI
       enableDynamicSizing
       enablePanDownToClose
       backdropComponent={renderBackdrop}
-      animateOnMount={!reducedMotion} // TODO remove when this issues is fixed https://github.com/gorhom/react-native-bottom-sheet/issues/1560
+      animateOnMount={!reducedMotion}
     >
       <BottomSheetContent>
         {downloadReceiptMutation.isPending ? (

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@aws-amplify/react-native": "~1.0.6",
     "@expo-google-fonts/inter": "~0.2.3",
     "@expo/vector-icons": "~14.0.2",
-    "@gorhom/bottom-sheet": "~4.5.1",
+    "@gorhom/bottom-sheet": "~4.6.4",
     "@gorhom/portal": "~1.0.14",
     "@js-joda/core": "~5.5.3",
     "@react-native-async-storage/async-storage": "1.23.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,10 +2245,10 @@
     find-up "^5.0.0"
     js-yaml "^4.1.0"
 
-"@gorhom/bottom-sheet@~4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-4.5.1.tgz#1ac4b234a80e7dff263f0b7ac207f92e41562849"
-  integrity sha512-4Qy6hzvN32fXu2hDxDXOIS0IBGBT6huST7J7+K1V5bXemZ08KIx5ZffyLgwhCUl+CnyeG2KG6tqk6iYLkIwi7Q==
+"@gorhom/bottom-sheet@~4.6.4":
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-4.6.4.tgz#387d0f0f21e3470eb8575498cb81ce96f5108e79"
+  integrity sha512-0itLMblLBvepE065w3a60S030c2rNUsGshPC7wbWDm31VyqoaU2xjzh/ojH62YIJOcobBr5QoC30IxBBKDGovQ==
   dependencies:
     "@gorhom/portal" "1.0.14"
     invariant "^2.2.4"


### PR DESCRIPTION
- removed todo text from gothom bottom sheet library issue because it's fixed in the latest version, but now it's feature, not a hotfix to a bug 😄,
- the height state of BottomSheetTopAttachment in new version of react-native-reanimated starts to be 0 in hook useAnimatedStyle. In my opinion it's because it runs on UI thread and state on JS thread so the value differs