### PR TITLE
#659 Add ios aps entitlement

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -17,6 +17,9 @@ module.exports = {
       supportsTablet: true,
       bundleIdentifier: 'com.bratislava.paas',
       googleServicesFile: './GoogleService-Info.plist',
+      entitlements: {
+        'aps-environment': 'development',
+      },
     },
     android: {
       adaptiveIcon: {

--- a/app.config.js
+++ b/app.config.js
@@ -3,7 +3,7 @@ module.exports = {
     name: 'PAAS',
     slug: 'paas',
     scheme: 'paasmpa',
-    version: '1.3.1',
+    version: '1.4.0',
     orientation: 'portrait',
     icon: './assets/app/icon.png',
     userInterfaceStyle: 'light',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paas",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
Add missing IOS APS entitlement to app.config.js.
Originally should have been added in the update to expo v51.