### PR TITLE
#212 Add rate app action row to about page

### DIFF
--- a/app/(app)/about/index.tsx
+++ b/app/(app)/about/index.tsx
@@ -15,7 +15,7 @@ import { navigateToStoreReview } from '@/utils/navigateToStore'
 const navigateToRoute = (url: string) => {
   router.navigate({
     pathname: '/about/webview',
-    params: { webviewUri: url } as WebviewSearchParams,
+    params: { webviewUri: url } satisfies WebviewSearchParams,
   })
 }
 

--- a/app/(app)/about/index.tsx
+++ b/app/(app)/about/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'expo-router'
+import { router } from 'expo-router'
 import { Fragment } from 'react'
 import { View } from 'react-native'
 
@@ -10,36 +10,44 @@ import ScreenView from '@/components/screen-layout/ScreenView'
 import Divider from '@/components/shared/Divider'
 import PressableStyled from '@/components/shared/PressableStyled'
 import { useTranslation } from '@/hooks/useTranslation'
+import { navigateToStoreReview } from '@/utils/navigateToStore'
+
+const navigateToRoute = (url: string) => {
+  router.navigate({
+    pathname: '/about/webview',
+    params: { webviewUri: url } as WebviewSearchParams,
+  })
+}
 
 const Page = () => {
   const { t } = useTranslation()
 
   /* Specify unique key for each item. Using label (with translation) was not working for React. */
-  const links = [
+  const items = [
     {
-      key: 1,
+      key: 'termsAndConditions',
       label: t('AboutScreen.links.termsAndConditions.label'),
-      url: t('AboutScreen.links.termsAndConditions.url'),
+      onPress: () => navigateToRoute(t('AboutScreen.links.termsAndConditions.url')),
       icon: 'language',
     },
     {
-      key: 2,
+      key: 'privacyPolicy',
       label: t('AboutScreen.links.privacyPolicy.label'),
-      url: t('AboutScreen.links.privacyPolicy.url'),
+      onPress: () => navigateToRoute(t('AboutScreen.links.privacyPolicy.url')),
       icon: 'description',
     },
     {
-      key: 3,
+      key: 'contactUs',
       label: t('AboutScreen.links.contactUs.label'),
-      url: t('AboutScreen.links.contactUs.url'),
+      onPress: () => navigateToRoute(t('AboutScreen.links.contactUs.url')),
       icon: 'phone',
     },
-    // {
-    //   key: 4,
-    //   label: t('AboutScreen.links.rateTheApp.label'),
-    //   url: t('AboutScreen.links.rateTheApp.url'),
-    //   icon: 'star',
-    // },
+    {
+      key: 'rateTheApp',
+      label: t('AboutScreen.links.rateTheApp.label'),
+      icon: 'star',
+      onPress: () => navigateToStoreReview(),
+    },
   ] as const
 
   return (
@@ -47,19 +55,12 @@ const Page = () => {
     <ScreenView title={t('AboutScreen.title')} actionButton={<AppVersion />}>
       <ScreenContent>
         <View>
-          {links.map((link) => (
-            <Fragment key={link.key}>
-              <Link
-                asChild
-                href={{
-                  pathname: `/about/webview`,
-                  params: { webviewUri: encodeURI(link.url) } satisfies WebviewSearchParams,
-                }}
-              >
-                <PressableStyled>
-                  <ListRow label={link.label} icon={link.icon} />
-                </PressableStyled>
-              </Link>
+          {items.map((item) => (
+            <Fragment key={item.key}>
+              <PressableStyled onPress={item.onPress}>
+                <ListRow label={item.label} icon={item.icon} />
+              </PressableStyled>
+
               <Divider />
             </Fragment>
           ))}

--- a/app/(app)/menu.tsx
+++ b/app/(app)/menu.tsx
@@ -84,7 +84,7 @@ const MainMenuScreen = () => {
             icon: 'developer-mode',
             path: '/dev',
           },
-        ] as MenuItemsType[])
+        ] satisfies MenuItemsType[])
       : []),
   ]
 

--- a/components/special/StoreVersionControl.tsx
+++ b/components/special/StoreVersionControl.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import * as Application from 'expo-application'
 import { useEffect, useState } from 'react'
-import { Linking, Platform } from 'react-native'
 
 import AvatarCircle from '@/components/info/AvatarCircle'
 import Modal from '@/components/screen-layout/Modal/Modal'
@@ -9,6 +8,7 @@ import ModalContentWithActions from '@/components/screen-layout/Modal/ModalConte
 import { environment } from '@/environment'
 import { useTranslation } from '@/hooks/useTranslation'
 import { mobileAppVersionOptions } from '@/modules/backend/constants/queryOptions'
+import { navigateToStore } from '@/utils/navigateToStore'
 
 const StoreVersionControl = () => {
   const { t } = useTranslation()
@@ -30,16 +30,6 @@ const StoreVersionControl = () => {
     }
   }, [appVersionQuery.data])
 
-  // eslint-disable-next-line unicorn/consistent-function-scoping
-  const goToStore = () => {
-    if (Platform.OS === 'ios') {
-      // TODO this link should be correct, but it does not work yet, probably due to App Store search indexing
-      Linking.openURL('https://apps.apple.com/app/paas/id6457264414')
-    } else {
-      Linking.openURL('https://play.google.com/store/apps/details?id=com.bratislava.paas')
-    }
-  }
-
   return (
     <Modal visible={showModal}>
       <ModalContentWithActions
@@ -47,7 +37,7 @@ const StoreVersionControl = () => {
         title={t('StoreVersionControl.title')}
         text={t('StoreVersionControl.text')}
         primaryActionLabel={t('StoreVersionControl.primaryActionLabel')}
-        primaryActionOnPress={goToStore}
+        primaryActionOnPress={navigateToStore}
       />
     </Modal>
   )

--- a/translations/en.json
+++ b/translations/en.json
@@ -3,6 +3,7 @@
   "AboutScreen.links.contactUs.url": "https://paas.sk/en/contact/",
   "AboutScreen.links.privacyPolicy.label": "Privacy policy",
   "AboutScreen.links.privacyPolicy.url": "https://paas.sk/en/privacy-policy/",
+  "AboutScreen.links.rateTheApp.label": "Rate the app",
   "AboutScreen.links.termsAndConditions.label": "Terms & conditions",
   "AboutScreen.links.termsAndConditions.url": "https://paas.sk/en/terms-of-use/",
   "AboutScreen.title": "About",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -3,6 +3,7 @@
   "AboutScreen.links.contactUs.url": "https://paas.sk/kontakt/",
   "AboutScreen.links.privacyPolicy.label": "Ochrana osobných údajov",
   "AboutScreen.links.privacyPolicy.url": "https://paas.sk/ochrana-osobnych-udajov/",
+  "AboutScreen.links.rateTheApp.label": "Ohodnoťte nás",
   "AboutScreen.links.termsAndConditions.label": "Všeobecné obchodné podmienky",
   "AboutScreen.links.termsAndConditions.url": "https://paas.sk/vseobecne-obchodne-podmienky/",
   "AboutScreen.title": "O nás",

--- a/utils/navigateToStore.ts
+++ b/utils/navigateToStore.ts
@@ -1,0 +1,28 @@
+import { Linking, Platform } from 'react-native'
+
+const appStoreId = 'id6457264414'
+const playStoreId = 'com.bratislava.paas'
+
+const nativeStoreUrl =
+  Platform.OS === 'ios'
+    ? `itms-apps://itunes.apple.com/app/id${appStoreId}`
+    : `market://details?id=${playStoreId}`
+
+const webStoreUrl =
+  Platform.OS === 'ios'
+    ? `https://apps.apple.com/app/${appStoreId}`
+    : `https://play.google.com/store/apps/details?id=${playStoreId}`
+
+export const navigateToStore = () => Linking.openURL(webStoreUrl)
+
+const reviewSuffix = Platform.OS === 'ios' ? '?action=write-review' : '&showAllReviews=true'
+
+export const navigateToStoreReview = async () => {
+  try {
+    const supported = await Linking.canOpenURL(nativeStoreUrl)
+
+    await Linking.openURL((supported ? nativeStoreUrl : webStoreUrl) + reviewSuffix)
+  } catch (error) {
+    console.error('An error occurred while opening the review page:', error)
+  }
+}


### PR DESCRIPTION
- refactor the about items to not support Link component, but router.navigate instead because some items need to not have Link there,
- add navigateToStore function that navigates to https links
- add navigateToStoreReviews function that has deeplink to stores which open reviews