### PR TITLE
#693 remove the additional click in add-vehicles test

### DIFF
--- a/.eas/build/build-and-maestro-test.yml
+++ b/.eas/build/build-and-maestro-test.yml
@@ -6,8 +6,8 @@ build:
         inputs:
           flow_path: |
             .maestro/login.yaml
-            .maestro/add-vehicles.yaml
-            .maestro/add-parking-cards.yaml
             .maestro/purchase.yaml
             .maestro/prolongate.yaml
             .maestro/shorten.yaml
+            .maestro/add-vehicles.yaml
+            .maestro/add-parking-cards.yaml

--- a/.maestro/add-vehicles.yaml
+++ b/.maestro/add-vehicles.yaml
@@ -11,7 +11,9 @@ appId: com.bratislava.paas
     id: licencePlate
 - inputText: BB222BB
 - tapOn: Add new
-- assertVisible: BB222BB
+- extendedWaitUntil:
+    visible: BB222BB
+    timeout: 5000
 - tapOn: Edit vehicle
 - tapOn:
     id: deleteVehicleBottomSheetPressable

--- a/.maestro/add-vehicles.yaml
+++ b/.maestro/add-vehicles.yaml
@@ -11,8 +11,6 @@ appId: com.bratislava.paas
     id: licencePlate
 - inputText: BB222BB
 - tapOn: Add new
-- tapOn:
-    id: Add vehicle
 - assertVisible: BB222BB
 - tapOn: Edit vehicle
 - tapOn:

--- a/.maestro/purchase.yaml
+++ b/.maestro/purchase.yaml
@@ -15,7 +15,6 @@ appId: com.bratislava.paas
         id: addParkingCardsModal
     commands:
       - tapOn: 'Later'
-- tapOn: Pay
 - tapOn:
     id: addVehicle
 - tapOn:


### PR DESCRIPTION
Change test according to the removal of the confirm modal for the normal type of licence plates