### PR TITLE
#702 Captcha second stage integration

### DIFF
--- a/.maestro/login.yaml
+++ b/.maestro/login.yaml
@@ -10,6 +10,12 @@ appId: com.bratislava.paas
 - tapOn: Enter phone number
 - waitForAnimationToEnd
 - tapOn: Continue
+- runFlow:
+    when:
+      visible:
+        id: expectedError
+    commands:
+      - tapOn: Continue
 - assertVisible: Enter 6-digit code
 - inputText: '123456'
 - assertVisible: Notifications

--- a/.maestro/prolongate.yaml
+++ b/.maestro/prolongate.yaml
@@ -4,6 +4,7 @@ appId: com.bratislava.paas
 - waitForAnimationToEnd
 - assertVisible:
     id: activeTicketsCount
+- waitForAnimationToEnd
 - tapOn:
     id: activeTicketsCount
 - tapOn: Prolong

--- a/.maestro/shorten.yaml
+++ b/.maestro/shorten.yaml
@@ -4,6 +4,7 @@ appId: com.bratislava.paas
 - waitForAnimationToEnd
 - assertVisible:
     id: activeTicketsCount
+- waitForAnimationToEnd
 - tapOn:
     id: activeTicketsCount
 - tapOn: Terminate

--- a/app/(auth)/sign-in/index.tsx
+++ b/app/(auth)/sign-in/index.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react-native'
 import { useEffect, useRef, useState } from 'react'
 import { ScrollView, View } from 'react-native'
 
@@ -112,10 +111,6 @@ const Page = () => {
     // The second stage of captcha integration includes the error message and signing in after the second try even when the captcha fails
     if (wasRetried) {
       setExpectedError('')
-      Sentry.captureException('Turnstile Captcha failed twice', {
-        extra: { errorCode },
-        level: 'info',
-      })
 
       // For now we call the signIn function even if the captcha fails to get data from lambda...
       // TODO: remove after 100% sure that the captcha is working
@@ -155,7 +150,9 @@ const Page = () => {
               </FlexRow>
 
               {expectedError ? (
-                <Typography className="text-negative">{translationKeys[expectedError]}</Typography>
+                <Typography testID="expectedError" className="text-negative">
+                  {translationKeys[expectedError]}
+                </Typography>
               ) : null}
             </View>
 

--- a/app/(auth)/sign-in/index.tsx
+++ b/app/(auth)/sign-in/index.tsx
@@ -53,7 +53,7 @@ const Page = () => {
     }
   }
 
-  const phoneWithoutSpaces = `+${prefixCode}${phone}`.replaceAll(/\s/g, '')
+  const phoneWithoutSpaces = phone.replaceAll(/\s/g, '')
 
   const handleRequestCaptcha = () => {
     setLoading(true)
@@ -62,11 +62,12 @@ const Page = () => {
 
   const handleSignIn = async (token: string, captchaErrorCode?: string) => {
     try {
-      if (!phone) {
+      if (!phoneWithoutSpaces) {
         throw new Error('No phone number')
       }
 
-      await attemptSignInOrSignUp(phoneWithoutSpaces, token, captchaErrorCode)
+      const phoneWithPrefix = `+${prefixCode}${phoneWithoutSpaces}`
+      await attemptSignInOrSignUp(phoneWithPrefix, token, captchaErrorCode)
     } catch (error) {
       // Expected errors are in SIGNIN_ERROR_CODES_TO_SHOW
       if (isErrorWithName(error)) {
@@ -158,7 +159,11 @@ const Page = () => {
 
             <Markdown>{t('Auth.consent')}</Markdown>
 
-            <ContinueButton loading={loading} disabled={!phone} onPress={handleRequestCaptcha} />
+            <ContinueButton
+              loading={loading}
+              disabled={!phoneWithoutSpaces}
+              onPress={handleRequestCaptcha}
+            />
 
             <Captcha ref={captchaRef} onSuccess={handleSignIn} onFail={handleCaptchaFail} />
           </ScreenContent>

--- a/components/inputs/Captcha.tsx
+++ b/components/inputs/Captcha.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native'
 import { forwardRef, useImperativeHandle, useState } from 'react'
 import WebView, { WebViewMessageEvent } from 'react-native-webview'
 
@@ -39,6 +40,11 @@ const Captcha = forwardRef<CaptchaRef, Props>(({ onSuccess, onFail }, ref) => {
 
       if (!hasRetried) {
         setHasRetried(true)
+      } else if (environment.deployment === 'production') {
+        Sentry.captureException('Turnstile Captcha failed twice', {
+          extra: { errorCode },
+          level: 'info',
+        })
       }
     } else {
       onSuccess(data)

--- a/components/inputs/Captcha.tsx
+++ b/components/inputs/Captcha.tsx
@@ -1,10 +1,17 @@
+import { forwardRef, useImperativeHandle, useState } from 'react'
 import WebView, { WebViewMessageEvent } from 'react-native-webview'
 
 import { environment } from '@/environment'
 
 type Props = {
   onSuccess: (token: string) => void
-  onFail: (errorCode: string) => void
+  onFail: (errorCode: string, wasRetried: boolean) => void
+}
+
+const CAPTCHA_ERROR_START_MESSAGE = 'error_'
+
+export type CaptchaRef = {
+  initializeCaptcha: () => void
 }
 
 /**
@@ -13,18 +20,34 @@ type Props = {
  * @param onSuccess Callback function that is called when the captcha is successfully solved. The token is passed as an argument.
  * @param onFail Callback function that is called when the captcha fails. The error code is passed as an argument and sent to the cognito.
  */
-const Captcha = ({ onSuccess, onFail }: Props) => {
+const Captcha = forwardRef<CaptchaRef, Props>(({ onSuccess, onFail }, ref) => {
+  const [hasRetried, setHasRetried] = useState<boolean>(false)
+  const [showCaptcha, setShowCaptcha] = useState<boolean>(false)
+
+  useImperativeHandle(ref, () => ({
+    initializeCaptcha: () => {
+      setShowCaptcha(true)
+    },
+  }))
+
   const handleMessage = (event: WebViewMessageEvent) => {
     const { data } = event.nativeEvent
+    if (data.startsWith(CAPTCHA_ERROR_START_MESSAGE)) {
+      const errorCode = data.split('_')[1]
 
-    if (data.split('_')[0] === 'error') {
-      onFail(data.split('_')[1])
+      onFail(errorCode, hasRetried)
+
+      if (!hasRetried) {
+        setHasRetried(true)
+      }
     } else {
       onSuccess(data)
     }
+
+    setShowCaptcha(false)
   }
 
-  return (
+  return showCaptcha ? (
     <WebView
       originWhitelist={['*']}
       onMessage={handleMessage}
@@ -47,8 +70,8 @@ const Captcha = ({ onSuccess, onFail }: Props) => {
                                 callback: function (token) {
                                     window.ReactNativeWebView.postMessage(token);
                                 },
-                                'error-callback': function (error) {
-                                    window.ReactNativeWebView.postMessage("error_" + error);
+                                'error-callback': function (errorCode) {
+                                    window.ReactNativeWebView.postMessage("${CAPTCHA_ERROR_START_MESSAGE}" + errorCode);
                                 }
                             });
                         }
@@ -58,7 +81,7 @@ const Captcha = ({ onSuccess, onFail }: Props) => {
         `,
       }}
     />
-  )
-}
+  ) : null
+})
 
 export default Captcha

--- a/eas.json
+++ b/eas.json
@@ -69,6 +69,7 @@
       "autoIncrement": false,
       "withoutCredentials": true,
       "config": "build-and-maestro-test.yml",
+      "resourceClass": "large",
       "android": {
         "buildType": "apk",
         "image": "latest"

--- a/translations/en.json
+++ b/translations/en.json
@@ -36,6 +36,7 @@
   "Auth.errors.Error": "An error occurred",
   "Auth.errors.InvalidParameterException": "Enter the phone number in international format (+421…)",
   "Auth.errors.NotAuthorizedException": "Submitted code has expired",
+  "Auth.errors.TurnstileCaptchaFailed": "CAPTCHA verification failed. Try again.",
   "Auth.modal.description": "Are you sure you want to log out?",
   "Auth.modal.title": "Logging out",
   "Auth.resendCode": "Resend code",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -36,6 +36,7 @@
   "Auth.errors.Error": "Vyskytla sa chyba",
   "Auth.errors.InvalidParameterException": "Zadajte číslo v medzinárodnom formáte (+421…)",
   "Auth.errors.NotAuthorizedException": "Platnosť kódu vypršala",
+  "Auth.errors.TurnstileCaptchaFailed": "Verifikácia CAPTCHA zlyhala. Skúste to znova.",
   "Auth.modal.description": "Ste si istý, že sa chcete odhlásiť?",
   "Auth.modal.title": "Odhlasovanie",
   "Auth.resendCode": "Odoslať kód znova",


### PR DESCRIPTION
The second stage includes two tries and then the signup.
We found some of the captcha verifications fail (10 in 5 days) so we want to know whether they will fail on second try, because turnstile docs suggest to retry the captcha on errors like those.

PR includes
- add retry to captcha after one failed one,
- add error message so user knows what is happening