### PR TITLE
#727 remove priceObject useMemo and cleanup useEffects

### DIFF
--- a/app/(app)/(purchase-and-payment)/purchase/index.tsx
+++ b/app/(app)/(purchase-and-payment)/purchase/index.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { Link, router, useFocusEffect } from 'expo-router'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, router } from 'expo-router'
+import React, { useEffect, useState } from 'react'
 import { ScrollView } from 'react-native'
 import { useDebounce } from 'use-debounce'
 
@@ -28,10 +28,7 @@ import {
   ticketPriceOptions,
   verifiedEmailsLengthOptions,
 } from '@/modules/backend/constants/queryOptions'
-import {
-  GetTicketPriceRequestDto,
-  InitiatePaymentRequestDto,
-} from '@/modules/backend/openapi-generated'
+import { InitiatePaymentRequestDto } from '@/modules/backend/openapi-generated'
 import { usePurchaseStoreContext } from '@/state/PurchaseStoreProvider/usePurchaseStoreContext'
 import { usePurchaseStoreUpdateContext } from '@/state/PurchaseStoreProvider/usePurchaseStoreUpdateContext'
 import { useVehiclesStoreContext } from '@/state/VehiclesStoreProvider/useVehiclesStoreContext'
@@ -45,7 +42,7 @@ const PurchaseScreen = () => {
   // TODO: find solution for height of bottom content with drawing
   const [purchaseButtonContainerHeight, setPurchaseButtonContainerHeight] = useState(0)
 
-  const [hasLicencePlateError, setHasLicencePlateError] = useState(false)
+  const [isTouched, setIsTouched] = useState(false)
 
   const { udr, vehicle, duration, npk, paymentOption, rememberCard } = usePurchaseStoreContext()
   const onPurchaseStoreUpdate = usePurchaseStoreUpdateContext()
@@ -61,11 +58,6 @@ const PurchaseScreen = () => {
   const isDebouncingDuration = duration !== debouncedDuration
 
   const parkingCardsQuery = useQuery(verifiedEmailsLengthOptions({ enabled: !firstPurchaseOpened }))
-
-  const priceRequestBody: GetTicketPriceRequestDto = useMemo(
-    () => createPriceRequestBody({ udr, licencePlate, duration: debouncedDuration, npk, locale }),
-    [udr, licencePlate, debouncedDuration, npk, locale],
-  )
 
   const handleModalClose = () => setIsAddCardModalOpen(false)
 
@@ -101,31 +93,16 @@ const PurchaseScreen = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultVehicle])
 
-  useEffect(() => {
-    if (licencePlate && hasLicencePlateError) {
-      setHasLicencePlateError(false)
-    }
-  }, [licencePlate, hasLicencePlateError])
-
   const priceQuery = useQueryWithFocusRefetch(
-    ticketPriceOptions(priceRequestBody, {
-      udr,
-      licencePlate,
-      duration: debouncedDuration,
-      npk,
-    }),
-  )
-
-  /**
-   * Refetch price every minute when screen is focused.
-   * Docs: https://docs.expo.dev/router/reference/hooks/#usefocuseffect.
-   */
-  useFocusEffect(
-    useCallback(() => {
-      const interval = setInterval(() => priceQuery.refetch(), 1000 * 60)
-
-      return () => clearInterval(interval)
-    }, [priceQuery]),
+    ticketPriceOptions(
+      createPriceRequestBody({ udr, licencePlate, duration: debouncedDuration, npk, locale }),
+      {
+        udr,
+        licencePlate,
+        duration: debouncedDuration,
+        npk,
+      },
+    ),
   )
 
   const handleSelectTime = (value: number) => {
@@ -138,17 +115,15 @@ const PurchaseScreen = () => {
   })
 
   const handlePressPay = () => {
-    if (!licencePlate) {
-      setHasLicencePlateError(true)
+    setIsTouched(true)
 
-      return
-    }
+    if (!licencePlate) return
 
     const actualPaymentOption = paymentOption ?? defaultPaymentOption
 
     initPaymentMutation.mutate(
       {
-        ...priceRequestBody,
+        ...createPriceRequestBody({ udr, licencePlate, duration: debouncedDuration, npk, locale }),
         rememberCard: actualPaymentOption === 'payment-card' ? rememberCard : false,
       } satisfies InitiatePaymentRequestDto,
       {
@@ -158,6 +133,8 @@ const PurchaseScreen = () => {
       },
     )
   }
+
+  const showLicencePlateError = isTouched && !licencePlate
 
   return (
     <>
@@ -170,7 +147,7 @@ const PurchaseScreen = () => {
               <Link testID="addVehicle" asChild href={{ pathname: '/purchase/choose-vehicle' }}>
                 <PressableStyled>
                   <VehicleFieldControl
-                    hasError={hasLicencePlateError}
+                    hasError={showLicencePlateError}
                     vehicle={vehicle?.isOneTimeUse ? vehicle : getVehicle(vehicle?.id)}
                   />
                 </PressableStyled>
@@ -212,7 +189,7 @@ const PurchaseScreen = () => {
         purchaseButtonContainerHeight={purchaseButtonContainerHeight}
         setPurchaseButtonContainerHeight={setPurchaseButtonContainerHeight}
         isLoading={initPaymentMutation.isPending || isDebouncingDuration}
-        hasLicencePlateError={hasLicencePlateError}
+        hasLicencePlateError={showLicencePlateError}
       />
 
       <Modal visible={isAddCardModalOpen} onRequestClose={handleModalClose}>

--- a/app/(app)/(purchase-and-payment)/purchase/index.tsx
+++ b/app/(app)/(purchase-and-payment)/purchase/index.tsx
@@ -42,7 +42,7 @@ const PurchaseScreen = () => {
   // TODO: find solution for height of bottom content with drawing
   const [purchaseButtonContainerHeight, setPurchaseButtonContainerHeight] = useState(0)
 
-  const [isTouched, setIsTouched] = useState(false)
+  const [isSubmitted, setIsSubmitted] = useState(false)
 
   const { udr, vehicle, duration, npk, paymentOption, rememberCard } = usePurchaseStoreContext()
   const onPurchaseStoreUpdate = usePurchaseStoreUpdateContext()
@@ -113,7 +113,7 @@ const PurchaseScreen = () => {
   })
 
   const handlePressPay = () => {
-    setIsTouched(true)
+    setIsSubmitted(true)
 
     if (!licencePlate) return
 
@@ -132,7 +132,7 @@ const PurchaseScreen = () => {
     )
   }
 
-  const showLicencePlateError = isTouched && !licencePlate
+  const showLicencePlateError = isSubmitted && !licencePlate
 
   return (
     <>

--- a/app/(app)/(purchase-and-payment)/purchase/index.tsx
+++ b/app/(app)/(purchase-and-payment)/purchase/index.tsx
@@ -93,17 +93,15 @@ const PurchaseScreen = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultVehicle])
 
-  const priceQuery = useQueryWithFocusRefetch(
-    ticketPriceOptions(
-      createPriceRequestBody({ udr, licencePlate, duration: debouncedDuration, npk, locale }),
-      {
-        udr,
-        licencePlate,
-        duration: debouncedDuration,
-        npk,
-      },
-    ),
-  )
+  const priceQueryBody = createPriceRequestBody({
+    udr,
+    licencePlate,
+    duration: debouncedDuration,
+    npk,
+    locale,
+  })
+
+  const priceQuery = useQueryWithFocusRefetch(ticketPriceOptions(priceQueryBody))
 
   const handleSelectTime = (value: number) => {
     onPurchaseStoreUpdate({ duration: value })
@@ -123,7 +121,7 @@ const PurchaseScreen = () => {
 
     initPaymentMutation.mutate(
       {
-        ...createPriceRequestBody({ udr, licencePlate, duration: debouncedDuration, npk, locale }),
+        ...priceQueryBody,
         rememberCard: actualPaymentOption === 'payment-card' ? rememberCard : false,
       } satisfies InitiatePaymentRequestDto,
       {

--- a/modules/backend/constants/queryOptions.ts
+++ b/modules/backend/constants/queryOptions.ts
@@ -4,10 +4,8 @@ import { clientApi } from '@/modules/backend/client-api'
 import {
   GetTicketPriceRequestDto,
   GetTicketProlongationPriceRequestDto,
-  ParkingCardDto,
 } from '@/modules/backend/openapi-generated'
 import { nextPageParam } from '@/modules/backend/utils/nextPageParam'
-import { MapUdrZone } from '@/modules/map/types'
 import { FilterTimeframesEnum } from '@/state/TicketsFiltersStoreProvider/TicketsFiltersStoreProvider'
 
 type PaginationOptions = {
@@ -115,28 +113,24 @@ export const verifiedEmailsInfiniteOptions = (options?: PageSize) => {
   })
 }
 
-export const ticketPriceOptions = (
-  body: GetTicketPriceRequestDto,
-  {
-    udr,
-    licencePlate,
-    duration,
-    npk,
-  }: {
-    udr: MapUdrZone | null
-    licencePlate: string
-    duration: number
-    npk: ParkingCardDto | null
-  },
-) =>
+export const ticketPriceOptions = (body: GetTicketPriceRequestDto) =>
   queryOptions({
-    queryKey: ['TicketPrice', udr, licencePlate, duration, npk],
+    queryKey: [
+      'TicketPrice',
+      body.ticket.udr,
+      body.ticket.ecv,
+      body.ticket.parkingEnd,
+      body.npkId,
+      body.ticket.udrUuid,
+      body.ticket.parkingStart,
+    ],
     queryFn: () => clientApi.ticketsControllerGetTicketPrice(body),
     select: (res) => res.data,
     // https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#removed-keeppreviousdata-in-favor-of-placeholderdata-identity-function
     placeholderData: keepPreviousData,
     refetchInterval: 1000 * 60,
-    enabled: !!udr && !!licencePlate && !!duration,
+    refetchIntervalInBackground: true,
+    enabled: !!body.ticket.udr && !!body.ticket.ecv && !!body.ticket.parkingEnd,
   })
 
 export const getTicketOptions = (ticketId?: number) =>

--- a/modules/backend/constants/queryOptions.ts
+++ b/modules/backend/constants/queryOptions.ts
@@ -129,7 +129,6 @@ export const ticketPriceOptions = (body: GetTicketPriceRequestDto) =>
     // https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#removed-keeppreviousdata-in-favor-of-placeholderdata-identity-function
     placeholderData: keepPreviousData,
     refetchInterval: 1000 * 60,
-    refetchIntervalInBackground: true,
     enabled: !!body.ticket.udr && !!body.ticket.ecv && !!body.ticket.parkingEnd,
   })
 

--- a/modules/backend/constants/queryOptions.ts
+++ b/modules/backend/constants/queryOptions.ts
@@ -135,6 +135,7 @@ export const ticketPriceOptions = (
     select: (res) => res.data,
     // https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#removed-keeppreviousdata-in-favor-of-placeholderdata-identity-function
     placeholderData: keepPreviousData,
+    refetchInterval: 1000 * 60,
     enabled: !!udr && !!licencePlate && !!duration,
   })
 


### PR DESCRIPTION
- remove price object useMemo,
- move refetch query interval inside queryOptions instead of useEffect,
- remove another redundant useEffect and rename vehicle state (i couldn't help myself and did it here)