### PR TITLE
fix: scrollable login and test fix

### DIFF
--- a/.maestro/login.yaml
+++ b/.maestro/login.yaml
@@ -16,6 +16,7 @@ appId: com.bratislava.paas
         id: expectedError
     commands:
       - tapOn: Continue
+- tapOn: Verify you are human
 - assertVisible: Enter 6-digit code
 - inputText: '123456'
 - assertVisible: Notifications

--- a/app.config.js
+++ b/app.config.js
@@ -3,7 +3,7 @@ module.exports = {
     name: 'PAAS',
     slug: 'paas',
     scheme: 'paasmpa',
-    version: '1.7.1',
+    version: '1.7.2',
     orientation: 'portrait',
     icon: './assets/app/icon.png',
     userInterfaceStyle: 'light',

--- a/app/(auth)/sign-in/index.tsx
+++ b/app/(auth)/sign-in/index.tsx
@@ -9,7 +9,6 @@ import TextInput from '@/components/inputs/TextInput'
 import ContinueButton from '@/components/navigation/ContinueButton'
 import ScreenContent from '@/components/screen-layout/ScreenContent'
 import ScreenView from '@/components/screen-layout/ScreenView'
-import DismissKeyboard from '@/components/shared/DismissKeyboard'
 import FlexRow from '@/components/shared/FlexRow'
 import Markdown from '@/components/shared/Markdown'
 import Typography from '@/components/shared/Typography'
@@ -119,53 +118,51 @@ const Page = () => {
   }
 
   return (
-    <DismissKeyboard>
-      <ScreenView hasBackButton={!isOnboardingFinished}>
-        <ScrollView alwaysBounceVertical={false}>
-          <ScreenContent>
-            <Typography variant="h1">{t('Auth.enterPhoneNumber')}</Typography>
+    <ScreenView hasBackButton={!isOnboardingFinished}>
+      <ScrollView alwaysBounceVertical={false} keyboardDismissMode="on-drag">
+        <ScreenContent>
+          <Typography variant="h1">{t('Auth.enterPhoneNumber')}</Typography>
 
-            <View className="g-1">
-              {/* Note that `onSubmitEditing` on iOS isn't called when using keyboardType="phone-pad": https://reactnative.dev/docs/textinput#onsubmitediting */}
-              {/* Adding returnKeyType="done" adds Done button above keyboard, otherwise, there is no "Enter" button */}
-              <FlexRow className="g-2.5">
-                <CountrySelectField selectedCountry={selectedCountry} />
+          <View className="g-1">
+            {/* Note that `onSubmitEditing` on iOS isn't called when using keyboardType="phone-pad": https://reactnative.dev/docs/textinput#onsubmitediting */}
+            {/* Adding returnKeyType="done" adds Done button above keyboard, otherwise, there is no "Enter" button */}
+            <FlexRow className="g-2.5">
+              <CountrySelectField selectedCountry={selectedCountry} />
 
-                <TextInput
-                  leftIcon={<Typography>+{prefixCode}</Typography>}
-                  viewClassName="flex-1"
-                  value={phone}
-                  onChangeText={handleChangeText}
-                  keyboardType="phone-pad"
-                  autoComplete="tel"
-                  hasError={!!expectedError}
-                  onFocus={handleInputFocus}
-                  autoFocus
-                  returnKeyType="done"
-                  onSubmitEditing={handleRequestCaptcha}
-                />
-              </FlexRow>
+              <TextInput
+                leftIcon={<Typography>+{prefixCode}</Typography>}
+                viewClassName="flex-1"
+                value={phone}
+                onChangeText={handleChangeText}
+                keyboardType="phone-pad"
+                autoComplete="tel"
+                hasError={!!expectedError}
+                onFocus={handleInputFocus}
+                autoFocus
+                returnKeyType="done"
+                onSubmitEditing={handleRequestCaptcha}
+              />
+            </FlexRow>
 
-              {expectedError ? (
-                <Typography testID="expectedError" className="text-negative">
-                  {translationKeys[expectedError]}
-                </Typography>
-              ) : null}
-            </View>
+            {expectedError ? (
+              <Typography testID="expectedError" className="text-negative">
+                {translationKeys[expectedError]}
+              </Typography>
+            ) : null}
+          </View>
 
-            <Markdown>{t('Auth.consent')}</Markdown>
+          <Markdown>{t('Auth.consent')}</Markdown>
 
-            <ContinueButton
-              loading={loading}
-              disabled={!phoneWithoutSpaces}
-              onPress={handleRequestCaptcha}
-            />
+          <ContinueButton
+            loading={loading}
+            disabled={!phoneWithoutSpaces}
+            onPress={handleRequestCaptcha}
+          />
 
-            <Captcha ref={captchaRef} onSuccess={handleSignIn} onFail={handleCaptchaFail} />
-          </ScreenContent>
-        </ScrollView>
-      </ScreenView>
-    </DismissKeyboard>
+          <Captcha ref={captchaRef} onSuccess={handleSignIn} onFail={handleCaptchaFail} />
+        </ScreenContent>
+      </ScrollView>
+    </ScreenView>
   )
 }
 

--- a/components/shared/DismissKeyboard.tsx
+++ b/components/shared/DismissKeyboard.tsx
@@ -8,6 +8,7 @@ type Props = {
 /**
  * Input helper component to dismiss Keyboard on click outside input
  * https://webcache.googleusercontent.com/search?q=cache:https://akshay-s-somkuwar.medium.com/dismiss-hide-keyboard-on-tap-outside-of-textinput-react-native-b94016f35ff0
+ * Cannot be used with ScrollView, scrollView has separate prop for this keyboardDismissMode="on-drag"
  */
 const DismissKeyboard = ({ children }: Props) => (
   <TouchableWithoutFeedback accessible={false} onPress={Keyboard.dismiss}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paas",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
`TouchableWithoutFeedback` inside `DismissKeyboard` component interacted badly with `ScrollView` and prevented it in some cases, 
- add comment to `DismissKeyboard` and checked all the usage with `ScrollView` (only one was in sign-in page),
- remove `DismissKeyboard` from sign-in and add `keyboardDismissMode="on-drag"` instead,
- fixed the login test