### PR TITLE
#769 Add initialRouteName to fix deep links

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -17,6 +17,12 @@ import TicketsFiltersStoreProvider from '@/state/TicketsFiltersStoreProvider/Tic
 import VehiclesStoreProvider from '@/state/VehiclesStoreProvider/VehiclesStoreProvider'
 import colors from '@/tailwind.config.colors'
 
+// eslint-disable-next-line babel/camelcase
+export const unstable_settings = {
+  // Ensure any route can link back to `/` (deep links to the app won't have back button without this)
+  initialRouteName: 'index',
+}
+
 const RootLayout = () => {
   const [mapboxLoaded, setMapboxLoaded] = useState(false)
   const [mapboxError, setMapboxError] = useState<Error | null>(null)

--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -20,6 +20,7 @@ import colors from '@/tailwind.config.colors'
 // eslint-disable-next-line babel/camelcase
 export const unstable_settings = {
   // Ensure any route can link back to `/` (deep links to the app won't have back button without this)
+  // https://docs.expo.dev/router/advanced/router-settings/
   initialRouteName: 'index',
 }
 


### PR DESCRIPTION
after going to application with deep link (to /tickets) we don't provide back button to return to index screen because router will put it as only item in stack, therefore we need to add initialRouteName to enable this in app layout

There was other option with useEffect and setting index route with each deep link (with `navigation.reset(...)`), but it's not good option.