### PR TITLE
Move queryClient out of the component 

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -66,6 +66,12 @@ const onFetchUpdateAsync = async () => {
   }
 }
 
+// The queryClient needs to be created outside of the component to avoid re-creating it on every render.
+const queryClient = new QueryClient({
+  // TODO - we change retries to 0 to see the behaviour in production, if it helps with too long waiting for expected errors response
+  defaultOptions: { queries: { retry: 0 } },
+})
+
 const RootLayout = () => {
   // Capture the NavigationContainer ref and register it with the instrumentation.
   const ref = useNavigationContainerRef()
@@ -90,11 +96,6 @@ const RootLayout = () => {
       onFetchUpdateAsync()
     }
   }, [])
-
-  const queryClient = new QueryClient({
-    // TODO - we change retries to 0 to see the behaviour in production, if it helps with too long waiting for expected errors response
-    defaultOptions: { queries: { retry: 0 } },
-  })
 
   const toastProviderProps = useToastProviderProps()
 

--- a/components/map/MapZoneBottomSheetAttachment.tsx
+++ b/components/map/MapZoneBottomSheetAttachment.tsx
@@ -1,6 +1,5 @@
-import { useQueryClient } from '@tanstack/react-query'
 import * as Location from 'expo-location'
-import { Link, useFocusEffect } from 'expo-router'
+import { Link } from 'expo-router'
 import { useCallback, useEffect, useState } from 'react'
 import { View } from 'react-native'
 
@@ -15,6 +14,7 @@ import PressableStyled from '@/components/shared/PressableStyled'
 import Typography from '@/components/shared/Typography'
 import { useQueryInvalidateOnTicketExpire } from '@/hooks/useQueryInvalidateOnTicketExpire'
 import { useQueryWithFocusRefetch } from '@/hooks/useQueryWithFocusRefetch'
+import { useRefetchOnScreenFocus } from '@/hooks/useRefetchOnScreenFocus'
 import { useTranslation } from '@/hooks/useTranslation'
 import { activeTicketsOptions } from '@/modules/backend/constants/queryOptions'
 import { useLocationPermission } from '@/modules/map/hooks/useLocationPermission'
@@ -63,19 +63,7 @@ const MapZoneBottomSheetAttachment = ({ flyTo, ...restProps }: Props) => {
   }, [flyTo, locationPermissionStatus])
 
   const { data: ticketsData, refetch } = useQueryWithFocusRefetch(activeTicketsOptions())
-
-  // Invalidate active tickets query on map focus to have fresh data when returning to the map
-  const queryClient = useQueryClient()
-  useFocusEffect(
-    useCallback(() => {
-      const queryState = queryClient.getQueryState(activeTicketsOptions().queryKey)
-
-      if (!queryState) refetch()
-      else if (queryState.status === 'success') {
-        queryClient.invalidateQueries({ queryKey: activeTicketsOptions().queryKey })
-      }
-    }, [queryClient, refetch]),
-  )
+  useRefetchOnScreenFocus(refetch)
 
   useQueryInvalidateOnTicketExpire(ticketsData?.tickets ?? null, refetch, ['Tickets'])
 

--- a/hooks/useRefetchOnScreenFocus.ts
+++ b/hooks/useRefetchOnScreenFocus.ts
@@ -1,9 +1,9 @@
 import { useFocusEffect } from 'expo-router'
 import React from 'react'
 
-// Function from tanstack query docs to refetch data when the screen is focused
+// Hook from Tanstack Query docs to refetch data when the screen is focused
 // https://tanstack.com/query/v4/docs/framework/react/react-native#refresh-on-screen-focus
-export function useRefetchOnScreenFocus<T>(refetch: () => Promise<T>) {
+export const useRefetchOnScreenFocus = <T>(refetch: () => Promise<T>) => {
   const firstTimeRef = React.useRef(true)
 
   useFocusEffect(

--- a/hooks/useRefetchOnScreenFocus.ts
+++ b/hooks/useRefetchOnScreenFocus.ts
@@ -1,0 +1,20 @@
+import { useFocusEffect } from 'expo-router'
+import React from 'react'
+
+// Function from tanstack query docs to refetch data when the screen is focused
+// https://tanstack.com/query/v4/docs/framework/react/react-native#refresh-on-screen-focus
+export function useRefetchOnScreenFocus<T>(refetch: () => Promise<T>) {
+  const firstTimeRef = React.useRef(true)
+
+  useFocusEffect(
+    React.useCallback(() => {
+      if (firstTimeRef.current) {
+        firstTimeRef.current = false
+
+        return
+      }
+
+      refetch()
+    }, [refetch]),
+  )
+}


### PR DESCRIPTION
The query client was created on each rerender of layout and it caused problems. 
Also added hook from Tanstack Query docs to refetch on page focus. (used in tickets query)