### PR TITLE
Change router.replace to .dismissTo on success Konto login screen

### DIFF
--- a/app/(app)/settings/notifications/result.tsx
+++ b/app/(app)/settings/notifications/result.tsx
@@ -33,7 +33,7 @@ const NotificationsResultPage = () => {
             </Button>
           </View>
         ) : (
-          <ContinueButton onPress={() => router.replace('/settings')}>
+          <ContinueButton onPress={() => router.dismissTo('/settings')}>
             {t('bloomreachNotifications.result.success.action')}
           </ContinueButton>
         )

--- a/app/(app)/settings/notifications/result.tsx
+++ b/app/(app)/settings/notifications/result.tsx
@@ -33,7 +33,7 @@ const NotificationsResultPage = () => {
             </Button>
           </View>
         ) : (
-          <ContinueButton onPress={() => router.dismissTo('/settings')}>
+          <ContinueButton onPress={() => router.dismissTo('/')}>
             {t('bloomreachNotifications.result.success.action')}
           </ContinueButton>
         )


### PR DESCRIPTION
This should ensure correct backbutton behaviour on settings screen after successful Konto login).