### PR TITLE
Invalidate consents query after Konto login and default consents setup

### DIFF
--- a/app/(app)/settings/notifications/city-account-login.tsx
+++ b/app/(app)/settings/notifications/city-account-login.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { getCurrentUser, updateUserAttribute } from 'aws-amplify/auth'
 import { router } from 'expo-router'
 import { useState } from 'react'
@@ -13,6 +14,7 @@ import { environment } from '@/environment'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useCityAccountSignIn } from '@/modules/auth/hooks/useCityAccountSignIn'
 import { clientApi } from '@/modules/backend/client-api'
+import { consentsOptions } from '@/modules/backend/constants/queryOptions'
 import {
   TrackConsentChangePropertiesDtoActionEnum,
   TrackConsentChangePropertiesDtoCategoryEnum,
@@ -24,6 +26,8 @@ const NotificationsHowPage = () => {
   const { signIn } = useCityAccountSignIn()
   const updateAuthStore = useAuthStoreUpdateContext()
   const [isLoading, setIsLoading] = useState(false)
+
+  const queryClient = useQueryClient()
 
   const handleSignIn = async () => {
     setIsLoading(true)
@@ -94,6 +98,9 @@ const NotificationsHowPage = () => {
           valid_until: 'unlimited',
         },
       })
+
+      // Invalidate consents query to refetch consents
+      await queryClient.invalidateQueries({ queryKey: consentsOptions().queryKey })
 
       await configureExponea(data.bloomreachContactId, user.signInDetails.loginId)
       updateAuthStore({ bloomreachId: data.bloomreachContactId })

--- a/app/(app)/settings/notifications/result.tsx
+++ b/app/(app)/settings/notifications/result.tsx
@@ -33,7 +33,7 @@ const NotificationsResultPage = () => {
             </Button>
           </View>
         ) : (
-          <ContinueButton onPress={() => router.dismissTo('/')}>
+          <ContinueButton onPress={() => router.dismissTo('/settings')}>
             {t('bloomreachNotifications.result.success.action')}
           </ContinueButton>
         )

--- a/components/notifications/BloomreachNotificationControls.tsx
+++ b/components/notifications/BloomreachNotificationControls.tsx
@@ -80,7 +80,7 @@ export const BloomreachNotificationControls = () => {
   }
 
   const getConsentValue = (category: ConsentItemDtoCategoryEnum) =>
-    query.data?.consents.find((c) => c.category === category)?.valid ?? false
+    query.data.consents.find((consent) => consent.category === category)?.valid ?? false
 
   const handleChange = (category: TrackConsentChangePropertiesDtoCategoryEnum, value: boolean) => {
     // Connect Email and SMS settings - SMS notifications are allowed only when Email notifications are enabled.


### PR DESCRIPTION
After successful Konto sign in, when redirected to `settings` screen, consents should refetch and show correct values instead of "all disabled".