### PR TITLE
Open the additionalInformation of UDR automatically

### DIFF
--- a/components/tickets/PurchaseBottomSheet.tsx
+++ b/components/tickets/PurchaseBottomSheet.tsx
@@ -37,6 +37,7 @@ const PurchaseBottomSheet = forwardRef<BottomSheet, Props>(
     return (
       <BottomSheet
         ref={ref}
+        index={udr?.additionalInformation ? 1 : 0}
         enableDynamicSizing
         bottomInset={purchaseButtonContainerHeight}
         snapPoints={snapPoints}


### PR DESCRIPTION
When opening the purchase screen of a ticket, show the additionalInformation about the UDR if there is any. 

Idea of this fix is that the default snapPoint for the `BottomSheet` component is `0` and the default value for `snapPoints` is `[HANDLE_HEIGHT]`.  When we want to expand the `BottomSheet` we need to wait for the height of the component to be calculated and appended into `snapPoints`. 

Tried a lot of other approaches, this is the only one that worked due to the `useEffects` being run before the other snapPoint is calculated